### PR TITLE
Fix documentation job

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,6 +1,8 @@
 name: Build documentation and deploy it to GitHub Pages
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
This patch should fix the documentation jobs. Previously the jobs were
triggered twice because of the pull_request and push conditions.

This change ensures that the push condition is true only when the patch
is being merged to main branch.