### PR TITLE
Mount TLS certificates to tempest container

### DIFF
--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -13,6 +13,7 @@ import (
 func Job(
 	instance *testv1beta1.Tempest,
 	labels map[string]string,
+	mountCerts bool,
 ) *batchv1.Job {
 
 	envVars := map[string]env.Setter{}
@@ -42,7 +43,7 @@ func Job(
 							Image:        instance.Spec.ContainerImage,
 							Args:         []string{},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: GetVolumeMounts(),
+							VolumeMounts: GetVolumeMounts(mountCerts),
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									ConfigMapRef: &corev1.ConfigMapEnvSource{
@@ -61,7 +62,7 @@ func Job(
 							},
 						},
 					},
-					Volumes: GetVolumes(instance),
+					Volumes: GetVolumes(mountCerts, instance),
 				},
 			},
 		},


### PR DESCRIPTION
This patch ensures we use tls certificate stored in secret named combined-ca-bundle when it is present in the openstack project.

When such a secret exists then we mount it to:
	- /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem.