### PR TITLE
Update documentation - uninstallation steps

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -1,25 +1,37 @@
-User Guide
-==========
+Run Tempest via test-operator
+=============================
 
-This guide is a starting point for configuring and running the `test-operator`.
+.. note::
+   Before you proceed with this section of the documentation please make sure
+   that you read the :ref:`prerequisites <prerequisites>`.
 
+This guide describes:
 
-Running Operator Locally Outside The Cluster
---------------------------------------------
-This is **quick and easy way** how to experiment with the operator during development of a
-new feature.
+* How to **install/uninstall** the operator?
 
-.. code-block:: bash
+  * :ref:`running-operator-olm`
 
-    make install run
+  * :ref:`running-operator-locally`
 
-Note, that after running the following command you will need to switch to
-another terminal unless you run it in the background.
+  * :ref:`uninstalling-operator`
 
-Running Operator Using The Operator Lifecycle Manager (OLM)
+* How to **run tests** via the the operator?
+
+  * :ref:`executing-tempest-tests`
+
+  * :ref:`custom-tempest-configuration`
+
+  * :ref:`getting-logs`
+
+If you want to get your hands on the test-operator quickly then follow these two
+sections: :ref:`running-operator-olm` and :ref:`executing-tempest-tests`.
+
+.. _running-operator-olm:
+
+Running Operator Using the Operator Lifecycle Manager (OLM)
 -----------------------------------------------------------
 
-Another option is to start the operator by running the pre-build operator image
+The first option of how to start the operator is by running the pre-build operator image
 stored on
 `quay.io <https://quay.io/repository/openstack-k8s-operators/test-operator>`_
 using the OLM.
@@ -34,7 +46,7 @@ using the OLM.
 
 Follow these steps to install the operator in the openstack project.
 
-1. Create **OperatorGroup**
+1. Create :code:`OperatorGroup`
 
 .. code-block:: yaml
 
@@ -53,7 +65,7 @@ Follow these steps to install the operator in the openstack project.
 
    oc apply -f operator-group.yaml
 
-2. Create **CatalogSource**
+2. Create :code:`CatalogSource`
 
 .. code-block:: yaml
 
@@ -72,7 +84,7 @@ Follow these steps to install the operator in the openstack project.
 
    oc apply -f catalog-source.yaml
 
-3. Create **Subscription**
+3. Create :code:`Subscription`
 
 .. code-block:: yaml
 
@@ -92,9 +104,10 @@ Follow these steps to install the operator in the openstack project.
 
    oc apply -f subscription.yaml
 
-4. Wait for the **test-operator-controller-manager** pod to successfully spawn. Once you see
-   the pod running you can start to communicate with the operator using the **Tempest** resource
-   defined below.
+4. Wait for the :code:`test-operator-controller-manager` pod to successfully
+   spawn. Once you see  the pod running you can start to communicate with the
+   operator using the :code:`Tempest` resource defined in the
+   :ref:`executing-tempest-tests` section.
 
 .. code-block:: bash
 
@@ -104,9 +117,108 @@ Follow these steps to install the operator in the openstack project.
    ...
 
 
+.. _running-operator-locally:
+
+Running Operator Locally Outside the Cluster
+--------------------------------------------
+This is **quick and easy way** how to experiment with the operator during
+development of a new feature.
+
+.. code-block:: bash
+
+    make install run
+
+Note, that after running the following command you will need to switch to
+another terminal unless you run it in the background.
+
+.. _uninstalling-operator:
+
+Uninstalling Operator
+---------------------
+
+If you installed the operator by following the steps in the
+:ref:`running-operator-olm` section then this section can come handy. You
+might need to uninstall the operator when:
+
+* you encountered issues during the installation process or when
+
+* you want to be sure that you are ussing the latest version of the operator.
+
+Please, make sure that you follow the order of the steps:
+
+1. Remove all instances of the :code:`Tempest` CRD
+
+.. code-block:: bash
+
+   oc get tempest
+
+   NAME            AGE
+   tempest-tests   3s
+
+
+.. code-block:: bash
+
+   oc delete tempest/tempest-tests
+
+2. Remove the :code:`crd`
+
+.. code-block:: bash
+
+   oc delete crd/tempests.test.openstack.org
+
+3. Remove the :code:`subscription` you created during
+   :ref:`the installation <running-operator-olm>`.
+
+.. code-block:: bash
+
+   oc delete subscription/test-operator
+
+4. Remove the :code:`catalog` source you created during
+   :ref:`the installation <running-operator-olm>`.
+
+.. code-block:: bash
+
+   oc delete catalogsource/test-operator-catalog
+
+6. Remove the :code:`operatorgroup` you created during
+   :ref:`the installation <running-operator-olm>`.
+
+.. code-block:: bash
+
+   oc delete operatorgroup/openstack-operatorgroup
+
+7. Remove the :code:`csv`
+
+.. code-block:: bash
+
+   oc delete csv/test-operator.v0.0.1
+
+8. Remove the :code:`operator`. It is possible that if you executed
+   the previous commands too quickly then you will need to execute this
+   command twice.
+
+.. code-block:: bash
+
+   oc delete operator/test-operator.openstack
+
+9. Check that there are no test-operator related resources hanging. This step
+   is not required.
+
+.. code-block:: bash
+
+   oc get olm
+
+.. note::
+   It might happen that by changing the order of the uninstallation steps,
+   you encounter a situation when you will not be able to delete the
+   :code:`crd`. In such a case, try to delete the :code:`finalizers:`
+   section in the output of the :code:`oc edit tempest/tempest-tests`.
+
+
+.. _executing-tempest-tests:
+
 Executing Tempest Tests
 -----------------------
-.. _Executing Tempest Tests:
 
 Once you have an operator running, then you can apply a tempest resource
 definition, e.g. the default one:
@@ -124,7 +236,7 @@ After that, verify that a pod was created with:
 
     oc get pods | grep tempest
 
-You should see a pod with a name like `tempest-tests-xxxxx`.
+You should see a pod with a name like :code:`tempest-tests-xxxxx`.
 
 To see the console output of the execution run the following:
 
@@ -132,9 +244,12 @@ To see the console output of the execution run the following:
 
     oc logs <name of the pod>
 
+
+.. _custom-tempest-configuration:
+
 Custom Tempest Configuration
 ----------------------------
-To configure tempest via tempest.conf use the `tempestconfRun.overrides`
+To configure tempest via tempest.conf use the :code:`tempestconfRun.overrides`
 parameter. This parameter accepts a list of key value pairs that specify values
 that should be written to tempest.conf generated inside the container.
 
@@ -171,6 +286,8 @@ will ensure that tempest will be executed with tempest.conf that looks like this
    ...
 
 
-Getting Logs
-------------
+.. _getting-logs:
+
+Getting Logs (TBA)
+------------------
 This is TBA.

--- a/docs/source/images.rst
+++ b/docs/source/images.rst
@@ -1,5 +1,5 @@
-Test Images
-===========
+Images Used by test-operator
+============================
 
 The `test-operator` uses images that are built and defined in
 `TCIB (The Container Image Build) <https://github.com/openstack-k8s-operators/tcib>`_.
@@ -20,7 +20,7 @@ Currently, there are the following tempest images:
 
   An image that contains only tempest and no other plugins. The user can install any external
   plugin during the container execution using the `tempestRun.externalPlugin*` parameters
-  (see :ref:`Executing Tempest Tests<Executing Tempest Tests>`)
+  (see :ref:`executing-tempest-tests`)
 
 * `openstack-tempest-all <https://quay.io/podified-antelope-centos9/openstack-tempest-all>`_
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,18 +14,18 @@ Overview
    :maxdepth: 1
 
    readme.md
+   images.rst
 
-Configuration Guide
-===================
+Running Test Operator
+=====================
 .. toctree::
    :maxdepth: 1
 
    prerequisites.rst
-   images.rst
    guide.rst
 
-Debugging
-=========
+Alternative Ways of Running Tempest Container
+=============================================
 .. toctree::
    :maxdepth: 1
 

--- a/docs/source/prerequisites.rst
+++ b/docs/source/prerequisites.rst
@@ -1,12 +1,11 @@
+.. _prerequisites:
+
 Prerequisites
 =============
 
 First, you will need an OpenStack Platform running on OpenShift. See, the
 `ci-framework documentation <https://ci-framework.readthedocs.io/en/latest/>`_
 to get you started. It will get you through the installation of such environment.
-
-E.g. if you want to install OpenStack Platform running on OpenShift on your
-own hardware, follow `the steps in this doc <https://ci-framework.readthedocs.io/en/latest/quickstart/04_non-virt.html>`_.
 
 After the installations is completed, you can source the credentials to the
 environment as follows:
@@ -16,6 +15,14 @@ environment as follows:
     eval $(${HOME}/ci-framework-data/bin/crc oc-env)
     export KUBECONFIG="${HOME}/.crc/machines/crc/kubeconfig"
     oc login -u kubeadmin -p 12345678 https://api.crc.testing:6443
+
+Once you source the credentials, please check that you are inside the
+openstack project.
+
+.. code-block:: bash
+
+   oc project openstack
+   Now using project "openstack" on server "https://api.crc.testing:6443".
 
 .. note::
     12345678 is a default password set by ci-framework


### PR DESCRIPTION
This patch adds a section to the documentation that describes how to uninstall the operator after the user used the installation steps for OLM.

The patch also fixes:

- capitalization of titles

- prerequisites section

- highlighting of code related portions of the documentation

- names of some sections of the documentation