### PR TITLE
Update RBAC rules for the test-operator

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -133,3 +133,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This patch updates the RBAC rules for the test-operator so that the controller can list persistent volume claims in the environment.

The change is needed in order to be able to sucessfully create pvcs from withing the operator.