### PR TITLE
Update RBAC rules for the test-operator

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -141,3 +141,5 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -97,6 +97,7 @@ func SecretExists(r *TempestReconciler, ctx context.Context, instance *testv1bet
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch
 
 // Reconcile - Tempest
 func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {


### PR DESCRIPTION
This patch updates the RBAC rules for the test-operator so that the controller can list persistent volume claims in the environment.

The change is needed in order to be able to sucessfully create pvcs from withing the operator. This patch is part of sequence of patches that test update the rbac rules.