### PR TITLE
[docs] Fix name of CatalogSource

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -74,7 +74,7 @@ Follow these steps to install the operator in the openstack project.
    apiVersion: operators.coreos.com/v1alpha1
    kind: CatalogSource
    metadata:
-     name: test-operator-index
+     name: test-operator-catalog
      namespace: openstack
    spec:
      sourceType: grpc


### PR DESCRIPTION
This patch fixes small typo in the documentation. We need to keep the name of the CatalogSource consistent. In the part of the documentation that is concerned with installation of the operator we use test-operator-index name and in the part of the documentation that describes the uninstallation of the operator we use test-operator-catalog.

This patch ensures that we use test-operator-catalog name for the catalogsource consistently.