### PR TITLE
[docs] Fix subscription definition

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -97,7 +97,7 @@ Follow these steps to install the operator in the openstack project.
      namespace: openstack
    spec:
      name: test-operator
-     source: test-operator-index
+     source: test-operator-catalog
      sourceNamespace: openstack
 
 .. code-block:: bash


### PR DESCRIPTION
The subscription in the documentation was using incorrect catalog source. This patch ensures that the subscription is using the test-operator-catalog instead of test-operator-index.