### PR TITLE
Fix job that builds the test-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,7 @@ RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
 # Build manager
 RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
 
-# (lpiwowar): Let's comment this out as we do use the templates folder now
-#             It causes a failure of a job that is responsible for building
-#             the operator.
-# RUN cp -r templates ${DEST_ROOT}/templates
+RUN cp -r templates ${DEST_ROOT}/templates
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
This patch reverts the change introduced here [1]. The patch did not resolve the issue.

This patch tries to fix this issue in simplier way and that is by keeping the templates directory.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/28