### PR TITLE
Change the interface for the tobiko CRD

### DIFF
--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -41,6 +41,10 @@ spec:
                   retried executions (defaults to 6).
                 format: int32
                 type: integer
+              config:
+                default: ""
+                description: tobiko.conf
+                type: string
               containerImage:
                 default: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
                 description: Container image for tobiko
@@ -49,35 +53,21 @@ spec:
                 default: true
                 description: Run tests in parallel
                 type: boolean
-              keystoneInterfaceName:
-                default: ""
-                description: Keystone interface name
-                type: string
               parallel:
                 default: false
                 description: Container image for tobiko
                 type: boolean
-              testcaseTimeout:
-                default: -1
-                description: Testcase timeout
-                format: int64
-                type: integer
+              privateKey:
+                default: ""
+                description: Private Key
+                type: string
+              publicKey:
+                default: ""
+                description: Public Key
+                type: string
               testenv:
                 default: py3
                 description: Test environment
-                type: string
-              testrunnerTimeout:
-                default: -1
-                description: Testrunner timeout
-                format: int64
-                type: integer
-              ubuntuInterfaceName:
-                default: ""
-                description: Ubuntu interface name
-                type: string
-              ubuntuMinimalImageURL:
-                default: ""
-                description: Ubuntu minimal image url
                 type: string
               version:
                 default: ""

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -53,28 +53,18 @@ type TobikoSpec struct {
 
         // +kubebuilder:validation:Optional
         // +kubebuilder:default:=""
-        // Ubuntu interface name
-        UbuntuInterfaceName string `json:"ubuntuInterfaceName,omitempty"`
+        // tobiko.conf
+        Config string `json:"config,omitempty"`
 
         // +kubebuilder:validation:Optional
         // +kubebuilder:default:=""
-        // Ubuntu minimal image url
-        UbuntuMinimalImageURL string `json:"ubuntuMinimalImageURL,omitempty"`
+        // Private Key
+        PrivateKey string `json:"privateKey,omitempty"`
 
         // +kubebuilder:validation:Optional
         // +kubebuilder:default:=""
-        // Keystone interface name
-        KeystoneInterfaceName string `json:"keystoneInterfaceName,omitempty"`
-
-        // +kubebuilder:validation:Optional
-        // +kubebuilder:default:=-1
-        // Testcase timeout
-        TestcaseTimeout int64 `json:"testcaseTimeout,omitempty"`
-
-        // +kubebuilder:validation:Optional
-        // +kubebuilder:default:=-1
-        // Testrunner timeout
-        TestrunnerTimeout int64 `json:"testrunnerTimeout,omitempty"`
+        // Public Key
+        PublicKey string `json:"publicKey,omitempty"`
 
 	// +kubebuilder:validation:Optional
         // +kubebuilder:default:="quay.io/podified-antelope-centos9/openstack-tobiko:current-podified"

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -41,6 +41,10 @@ spec:
                   retried executions (defaults to 6).
                 format: int32
                 type: integer
+              config:
+                default: ""
+                description: tobiko.conf
+                type: string
               containerImage:
                 default: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
                 description: Container image for tobiko
@@ -49,35 +53,21 @@ spec:
                 default: true
                 description: Run tests in parallel
                 type: boolean
-              keystoneInterfaceName:
-                default: ""
-                description: Keystone interface name
-                type: string
               parallel:
                 default: false
                 description: Container image for tobiko
                 type: boolean
-              testcaseTimeout:
-                default: -1
-                description: Testcase timeout
-                format: int64
-                type: integer
+              privateKey:
+                default: ""
+                description: Private Key
+                type: string
+              publicKey:
+                default: ""
+                description: Public Key
+                type: string
               testenv:
                 default: py3
                 description: Test environment
-                type: string
-              testrunnerTimeout:
-                default: -1
-                description: Testrunner timeout
-                format: int64
-                type: integer
-              ubuntuInterfaceName:
-                default: ""
-                description: Ubuntu interface name
-                type: string
-              ubuntuMinimalImageURL:
-                default: ""
-                description: Ubuntu minimal image url
                 type: string
               version:
                 default: ""

--- a/config/samples/test_v1beta1_tobiko.yaml
+++ b/config/samples/test_v1beta1_tobiko.yaml
@@ -10,4 +10,4 @@ metadata:
     app.kubernetes.io/created-by: test-operator
   name: tobiko-sample
 spec:
-  # TODO(user): Add fields here
+

--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -14,6 +14,7 @@ func Job(
 	instance *testv1beta1.Tobiko,
 	labels map[string]string,
 	mountCerts bool,
+	mountKeys bool,
 	envVars map[string]env.Setter,
 ) *batchv1.Job {
 
@@ -43,10 +44,10 @@ func Job(
 							Image:        instance.Spec.ContainerImage,
 							Args:         []string{},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: GetVolumeMounts(mountCerts),
+							VolumeMounts: GetVolumeMounts(mountCerts, mountKeys),
 						},
 					},
-					Volumes: GetVolumes(mountCerts, instance),
+					Volumes: GetVolumes(mountCerts, mountKeys, instance),
 				},
 			},
 		},


### PR DESCRIPTION
With this change in the tobiko image we have to change the tobiko CRD. We will no longer use ENV variables to specify individual config options in tobiko.conf. Instead we are letting the user to specify the tobiko.conf directly in the Tobiko CRD [1].

This patch also introduces two new options (privateKey and publicKey) to comply with the tobiko tcib image [2].

[1] https://github.com/openstack-k8s-operators/tcib/pull/120
[2] https://github.com/openstack-k8s-operators/tcib/pull/120