### PR TITLE
Allow the user to specify storageclass

### DIFF
--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -113,6 +113,10 @@ spec:
                 default: false
                 description: Execute tests parallely
                 type: boolean
+              storageClass:
+                default: local-storage
+                description: StorageClass used to create PVCs that store the logs
+                type: string
               tempestRun:
                 description: TempestSpec TempestRun parts
                 properties:
@@ -283,6 +287,7 @@ spec:
             - containerImage
             - openStackConfigMap
             - openStackConfigSecret
+            - storageClass
             type: object
           status:
             description: TempestStatus defines the observed state of Tempest

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -65,6 +65,10 @@ spec:
                 default: ""
                 description: Public Key
                 type: string
+              storageClass:
+                default: local-storage
+                description: StorageClass used to create PVCs that store the logs
+                type: string
               testenv:
                 default: py3
                 description: Test environment
@@ -73,6 +77,8 @@ spec:
                 default: ""
                 description: Tobiko version
                 type: string
+            required:
+            - storageClass
             type: object
           status:
             description: TobikoStatus defines the observed state of Tobiko

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -229,6 +229,11 @@ type TempestconfRunSpec struct {
 // TempestSpec defines the desired state of Tempest
 type TempestSpec struct {
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default="local-storage"
+        // StorageClass used to create PVCs that store the logs
+	StorageClass string `json:"storageClass"`
+
+	// +kubebuilder:validation:Required
 	// Tempest Container Image URL (will be set to environmental default if empty)
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -36,6 +36,11 @@ type Hash struct {
 
 // TobikoSpec defines the desired state of Tobiko
 type TobikoSpec struct {
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default="local-storage"
+        // StorageClass used to create PVCs that store the logs
+	StorageClass string `json:"storageClass"`
+
 	// +kubebuilder:validation:Optional
         // +kubebuilder:default:=true
         // Run tests in parallel

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -113,6 +113,10 @@ spec:
                 default: false
                 description: Execute tests parallely
                 type: boolean
+              storageClass:
+                default: local-storage
+                description: StorageClass used to create PVCs that store the logs
+                type: string
               tempestRun:
                 description: TempestSpec TempestRun parts
                 properties:
@@ -283,6 +287,7 @@ spec:
             - containerImage
             - openStackConfigMap
             - openStackConfigSecret
+            - storageClass
             type: object
           status:
             description: TempestStatus defines the observed state of Tempest

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -65,6 +65,10 @@ spec:
                 default: ""
                 description: Public Key
                 type: string
+              storageClass:
+                default: local-storage
+                description: StorageClass used to create PVCs that store the logs
+                type: string
               testenv:
                 default: py3
                 description: Test environment
@@ -73,6 +77,8 @@ spec:
                 default: ""
                 description: Tobiko version
                 type: string
+            required:
+            - storageClass
             type: object
           status:
             description: TobikoStatus defines the observed state of Tobiko

--- a/config/samples/test_v1beta1_tempest.yaml
+++ b/config/samples/test_v1beta1_tempest.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: openstack
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-tempest:current-podified
+  # storageClass: local-storage
+  # parallel: false
   tempestRun:
     # NOTE: All parameters have default values (use only when you want to override
     #       the default behaviour)

--- a/config/samples/test_v1beta1_tobiko.yaml
+++ b/config/samples/test_v1beta1_tobiko.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: openstack
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
+  # storageClass: local-storage
+  # parallel: false
   testenv: py3
   version: master
   config: |

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -39,7 +39,13 @@ func (r *Reconciler) CheckSecretExists(ctx context.Context, instance client.Obje
 	}
 }
 
-func (r *Reconciler) EnsureLogsPVCExists(ctx context.Context, instance client.Object, helper *helper.Helper, NamePVC string) (ctrl.Result, error) {
+func (r *Reconciler) EnsureLogsPVCExists(
+	ctx context.Context,
+	instance client.Object,
+	helper *helper.Helper,
+	NamePVC string,
+	StorageClassName string) (ctrl.Result, error) {
+
 	pvvc := &corev1.PersistentVolumeClaim{}
 	err := r.Client.Get(ctx, client.ObjectKey{Namespace: instance.GetNamespace(), Name: NamePVC}, pvvc)
 	if err == nil {
@@ -61,6 +67,7 @@ func (r *Reconciler) EnsureLogsPVCExists(ctx context.Context, instance client.Ob
 					corev1.ResourceStorage: k8sresource.MustParse("1Gi"),
 				},
 			},
+			StorageClassName: &StorageClassName,
 		},
 	}
 

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -187,7 +187,7 @@ func (r *TempestReconciler) reconcileNormal(ctx context.Context, instance *testv
 	//
 
 	// Create PersistentVolumeClaim
-	ctrlResult, err := r.EnsureLogsPVCExists(ctx, instance, helper, instance.Name)
+	ctrlResult, err := r.EnsureLogsPVCExists(ctx, instance, helper, instance.Name, instance.Spec.StorageClass)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -167,7 +167,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Create PersistentVolumeClaim
-	ctrlResult, err := r.EnsureLogsPVCExists(ctx, instance, helper, instance.Name)
+	ctrlResult, err := r.EnsureLogsPVCExists(ctx, instance, helper, instance.Name, instance.Spec.StorageClass)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -144,7 +144,7 @@ might need to uninstall the operator when:
 
 Please, make sure that you follow the order of the steps:
 
-1. Remove all instances of the :code:`Tempest` CRD
+1. Remove all instances of the :code:`Tempest` and :code:`Tobiko` CRDs
 
 .. code-block:: bash
 
@@ -157,12 +157,14 @@ Please, make sure that you follow the order of the steps:
 .. code-block:: bash
 
    oc delete tempest/tempest-tests
+   oc delete tobiko/tobiko-tests
 
 2. Remove the :code:`crd`
 
 .. code-block:: bash
 
    oc delete crd/tempests.test.openstack.org
+   oc delete crd/tobikoes.test.openstack.org
 
 3. Remove the :code:`subscription` you created during
    :ref:`the installation <running-operator-olm>`.


### PR DESCRIPTION
This patch makes sure that the user can specify a storageclass that is used by the test-operator to generate pvc. Previously the test-operator could fail when there was no default storageclass.