### PR TITLE
[docs] Update the "Getting Logs" section and Tobiko CRD

### DIFF
--- a/config/samples/test_v1beta1_tobiko.yaml
+++ b/config/samples/test_v1beta1_tobiko.yaml
@@ -8,6 +8,10 @@ spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
   # storageClass: local-storage
   # parallel: false
+  # privateKey: |
+  #   <private-key-value>
+  # publicKey: |
+  #   <public-key-value>
   testenv: py3
   version: master
   config: |

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -270,6 +270,11 @@ The test-operator creates a persistent volume that is attached to a pod executin
 the tests. Once the pod completes test execution, the pv contains all the artifacts
 associated with the test run.
 
+.. note::
+   Please keep in mind that all resources created by the test operator are bound
+   to the CR. Once you remove the CR (e.g.::code:`tempest/tempest-tests`), then
+   you also remove the PV containing the logs.
+
 If you want to retrieve the logs from the pv, you can follow these steps:
 
 1. Spawn a pod with the pv attached to it.
@@ -298,7 +303,7 @@ If you want to retrieve the logs from the pv, you can follow these steps:
             #       have to put here the value from metadata.name.
             claimName: tempest-tests
 
-2 (a). Get an access to the logs by connecting to the pod created in the fist
+2. Get an access to the logs by connecting to the pod created in the first
 step:
 
 .. code-block:: bash
@@ -306,7 +311,7 @@ step:
    oc rsh pod/test-operator-logs-pod
    cd /mnt
 
-2 (b). Or get an access to the logs by copying the artifacts out of the pod created
+**OR** get an access to the logs by copying the artifacts out of the pod created
 in the first step:
 
 .. code-block:: bash


### PR DESCRIPTION
Based on the feedback from the users of the documentation we need to make the "Getting Logs" section more readable. Specifically, we want to:
- Remind the readers that by removing the CR you also remove the PV containing the logs.
- Be more explicit in the fact that there are two options for how to perform the second step of getting the logs.

This PR also updates the tobiko CR so that it contains the new values: privateKey and publicKey.