### PR TITLE
Remove duplicite service-labels

### DIFF
--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -227,10 +227,6 @@ func (r *TempestReconciler) reconcileNormal(ctx context.Context, instance *testv
 	}
 	// Create PersistentVolumeClaim - end
 
-	serviceLabels := map[string]string{
-		common.AppSelector: tempest.ServiceName,
-	}
-
 	mountSSHKey := false
 	if instance.Spec.SSHKeySecretName != "" {
 		mountSSHKey = r.CheckSecretExists(ctx, instance, instance.Spec.SSHKeySecretName)


### PR DESCRIPTION
This patch introduced duplicite serviceLabels variable during the rebase on top of main. Let's fix this issue by simply removing the duplicite lines.