### PR TITLE
Run tobiko pod as root with NET_ADMIN,NET_RAW capabilities

### DIFF
--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -18,8 +18,8 @@ func Job(
 	envVars map[string]env.Setter,
 ) *batchv1.Job {
 
-	runAsUser := int64(42495)
-	runAsGroup := int64(42495)
+	runAsUser := int64(0)
+	runAsGroup := int64(0)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -45,6 +45,11 @@ func Job(
 							Args:         []string{},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: GetVolumeMounts(mountCerts, mountKeys),
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
+								},
+							},
 						},
 					},
 					Volumes: GetVolumes(mountCerts, mountKeys, instance),


### PR DESCRIPTION
Tobiko requires to run as root in order to be able to run tcpdump command and needs NET_ADMIN and NET_RAW capabilities. Tcpdump command is currently being used by only one test in tobiko:

- tobiko/tests/scenario/neutron/test_qos.py::QoSNetworkTest::test_ping_dscp