### PR TITLE
Enable hostNetwork on test pods

### DIFF
--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -31,6 +31,7 @@ func Job(
 			BackoffLimit: instance.Spec.BackoffLimit,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					HostNetwork:        true,
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: instance.RbacResourceName(),
 					SecurityContext: &corev1.PodSecurityContext{

--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -31,6 +31,7 @@ func Job(
 			BackoffLimit: instance.Spec.BackoffLimit,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					HostNetwork:        true,
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: instance.RbacResourceName(),
 					SecurityContext: &corev1.PodSecurityContext{


### PR DESCRIPTION
In order to avoid connectivity problems from the test-operator, this patch enables hostNetwork on both tempest and tobiko pods by default. Hence, the test pods will use the OCP worker (or CRC) network configuration directly.