### PR TITLE
[Tobiko] Introduce KubeconfigSecretName parameter

### DIFF
--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -53,6 +53,11 @@ spec:
                 default: true
                 description: Run tests in parallel
                 type: boolean
+              kubeconfigSecretName:
+                default: ""
+                description: Name of a secret that contains a kubeconfig. The kubeconfig
+                  is mounted under /var/lib/tobiko/.kube/config in the test pod.
+                type: string
               parallel:
                 default: false
                 description: Container image for tobiko

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -81,11 +81,16 @@ type TobikoSpec struct {
         // Container image for tobiko
         Parallel bool `json:"parallel,omitempty"`
 
-
 	// BackoffLimimt allows to define the maximum number of retried executions (defaults to 6).
         // +kubebuilder:default:=0
         // +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
         BackoffLimit *int32 `json:"backoffLimit,omitempty"`
+
+        // Name of a secret that contains a kubeconfig. The kubeconfig is mounted under /var/lib/tobiko/.kube/config
+        // in the test pod.
+        // +kubebuilder:default:=""
+        // +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+        KubeconfigSecretName string `json:"kubeconfigSecretName,omitempty"`
 }
 
 // TobikoStatus defines the observed state of Tobiko

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -53,6 +53,11 @@ spec:
                 default: true
                 description: Run tests in parallel
                 type: boolean
+              kubeconfigSecretName:
+                default: ""
+                description: Name of a secret that contains a kubeconfig. The kubeconfig
+                  is mounted under /var/lib/tobiko/.kube/config in the test pod.
+                type: string
               parallel:
                 default: false
                 description: Container image for tobiko

--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -15,11 +15,12 @@ func Job(
 	labels map[string]string,
 	mountCerts bool,
 	mountKeys bool,
+	mountKubeconfig bool,
 	envVars map[string]env.Setter,
 ) *batchv1.Job {
 
-	runAsUser := int64(0)
-	runAsGroup := int64(0)
+	runAsUser := int64(42495)
+	runAsGroup := int64(42495)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -44,15 +45,15 @@ func Job(
 							Image:        instance.Spec.ContainerImage,
 							Args:         []string{},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: GetVolumeMounts(mountCerts, mountKeys),
+							VolumeMounts: GetVolumeMounts(mountCerts, mountKeys, mountKubeconfig),
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW", "CAP_AUDIT_WRITE"},
 								},
 							},
 						},
 					},
-					Volumes: GetVolumes(mountCerts, mountKeys, instance),
+					Volumes: GetVolumes(mountCerts, mountKeys, mountKubeconfig, instance),
 				},
 			},
 		},


### PR DESCRIPTION
This patch introduces KubeconfigSecretName parameter that can be used to mount kubeconfig to the tobiko test pod. The parameter accepts a name of a secret that contains the content of kubeconfig under "config" key value. The kubeconfig is mounted to /var/lib/tobiko/.kube/config

[OSPRH-4936](https://issues.redhat.com/browse/OSPRH-4936)