### PR TITLE
[Tobiko] Add CAP_AUDIT_WRITE capability

### DIFF
--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -47,7 +47,7 @@ func Job(
 							VolumeMounts: GetVolumeMounts(mountCerts, mountKeys),
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW", "CAP_AUDIT_WRITE"},
 								},
 							},
 						},


### PR DESCRIPTION
The tobiko image uses sudo command that requires a CAP_AUDIT_WRITE capabilities in order to be able to write to kernel audit log. If the capability is missing we get the following error msg:

"sudo: unable to send audit message: Operation not permitted"

The message has no influence on successful execution of the tests but can be confusing for the users of the test-operator. Therefore we are enabling the capability by default.