### PR TITLE
Assign correct owner of the tobiko ssh keys

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -29,9 +29,6 @@
                   service_available.cinder false
               cifmw_run_tobiko: true
               cifmw_test_operator_tobiko_testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'
-              cifmw_test_operator_tobiko_override_conf:
-                rhosp:
-                  ssh_key_filename: '~/tobiko_keys/osp_ssh_key'
             required-projects: &rp
               - name: openstack-k8s-operators/install_yamls
                 override-checkout: main

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -120,6 +120,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if instance.Spec.NumProcesses > 0 {
 		envVars["TOX_NUM_PROCESSES"] = env.SetValue(strconv.Itoa(int(instance.Spec.NumProcesses)))
 	}
+	envVars["TOBIKO_KEYS_FOLDER"] = env.SetValue("/etc/test_operator")
 	// Prepare env vars - end
 
 	// Prepare custom data

--- a/pkg/tobiko/volumes.go
+++ b/pkg/tobiko/volumes.go
@@ -11,7 +11,7 @@ func GetVolumes(mountCerts bool, mountKeys bool, mountKubeconfig bool, instance 
 	var scriptsVolumeDefaultMode int32 = 0755
 	var scriptsVolumeConfidentialMode int32 = 0420
 	var privateKeyMode int32 = 0600
-	var publicKeyMode int32 = 0655
+	var publicKeyMode int32 = 0644
 	var tlsCertificateMode int32 = 0444
 
 	volumes := []corev1.Volume{
@@ -206,7 +206,7 @@ func GetVolumeMounts(mountCerts bool, mountKeys bool, mountKubeconfig bool) []co
 	if mountKeys {
 		keysMount := corev1.VolumeMount{
 			Name:      "tobiko-private-key",
-			MountPath: "/var/lib/tobiko/.ssh/id_ecdsa",
+			MountPath: "/etc/test_operator/id_ecdsa",
 			SubPath:   "id_ecdsa",
 			ReadOnly:  true,
 		}
@@ -215,7 +215,7 @@ func GetVolumeMounts(mountCerts bool, mountKeys bool, mountKubeconfig bool) []co
 
 		keysMount = corev1.VolumeMount{
 			Name:      "tobiko-public-key",
-			MountPath: "/var/lib/tobiko/.ssh/id_ecdsa.pub",
+			MountPath: "/etc/test_operator/id_ecdsa.pub",
 			SubPath:   "id_ecdsa.pub",
 			ReadOnly:  true,
 		}


### PR DESCRIPTION
There seems to be issues with mounting ssh keys into the tobiko testpod. This issue can be resolved by mounting the keys to /etc/test_operator and leaving the tobiko tcib image to handle setting correct permissions and moving the keys to a correct folder on its own.

Depends-On: https://github.com/openstack-k8s-operators/tcib/pull/138