### PR TITLE
Remove the check job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -51,6 +51,3 @@
                 override-checkout: main
               - name: github.com/openstack-k8s-operators/openstack-must-gather
                 override-checkout: main
-    github-check:
-      jobs:
-        - podified-multinode-edpm-deployment-crc: *podified_multinode_edpm_deployment_crc


### PR DESCRIPTION
Let's remove the job in the github-check pipeline. Currently we do not have the mechanism to build the test-operator on the go and pass it to the job. Therefore the check job would not be testing the changes in a PR and would only waste resources.