### PR TITLE
Fix/docs

### DIFF
--- a/config/samples/test_v1beta1_tempest.yaml
+++ b/config/samples/test_v1beta1_tempest.yaml
@@ -48,14 +48,16 @@ spec:
     # timeout: 600
     # imageDiskFormat: qcow2
     # image: https://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
-    # The following text will be mounted to the tempest pod
-    # as deployer_input.yaml
-    # deployerInput: |
-    #  value1: exmaple_value2
-    #  value2: example_value2
 
     # The following text will be mounted to the tempest pod
     # as /etc/test_operator/deployer_input.yaml
+    # deployerInput: |
+    #   [section]
+    #   value1 = exmaple_value2
+    #   value2 = example_value2
+
+    # The following text will be mounted to the tempest pod
+    # as /etc/test_operator/accounts.yaml
     # testAccounts: |
     #  - username: 'multi_role_user'
     #    tenant_name: 'test_tenant_42'
@@ -67,7 +69,10 @@ spec:
 
     # The following text will be mounted to the tempest pod
     # as /etc/test_operator/profile.yaml
-    # testAccounts: |
+    # profile: |
+    #   collect_timing: false
+    #   create: false
+    #   create_accounts_file: null
 
     # createAccountsFile: /path/to/accounts.yaml
     # generateProfile: /path/to/profile.yaml

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -352,7 +352,7 @@ func (r *TempestReconciler) setTempestconfConfigVars(envVars map[string]string,
 	// Files
 	testOperatorDir := "/etc/test_operator/"
 	if len(tempestconfRun.DeployerInput) != 0 {
-		deployerInputFile := "deployer_input.yaml"
+		deployerInputFile := "deployer_input.ini"
 		customData[deployerInputFile] = tempestconfRun.DeployerInput
 		envVars["TEMPESTCONF_DEPLOYER_INPUT"] = testOperatorDir + deployerInputFile
 	}


### PR DESCRIPTION
Fix deployerInput, profile, accounts sections and deployerInput format

This patch fixes:

- small inaccuracies in the TempestCR in the documentation.
- and file extension for the deployerInput file created by the test operator. The correct extension is .ini not .yaml
