### PR TITLE
[Tempest] Add correct labels

### DIFF
--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -190,6 +190,8 @@ func (r *TempestReconciler) reconcileNormal(ctx context.Context, instance *testv
 
 	serviceLabels := map[string]string{
 		common.AppSelector: tempest.ServiceName,
+		"workflowStep":     "0",
+		"instanceName":     instance.Name,
 	}
 
 	// NetworkAttachments


### PR DESCRIPTION
With this update [1] in the test_operator ci-framework role we are no longer waiting for a job using its name but labels named "workflowStep" and "instanceName". This patch adds these labels for tempest in order to prevent the job timeouts.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1235