### PR TITLE
Run a two-steps tobiko workflow

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -28,7 +28,12 @@
                   service_available.swift false
                   service_available.cinder false
               cifmw_run_tobiko: true
-              cifmw_test_operator_tobiko_testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'
+              cifmw_test_operator_tobiko_workflow:
+                - stepName: 'podified-functional'
+                  testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'
+                  numProcesses: 2
+                - stepName: 'sanity'
+                  testenv: 'sanity'
             required-projects: &rp
               - name: openstack-k8s-operators/install_yamls
                 override-checkout: main


### PR DESCRIPTION
The test-operator periodic job podified-multinode-edpm-deployment-crc will run a tobiko workflow with two test steps.