### PR TITLE
[Tempest] Introduce KubeconfigSecretName parameter

### DIFF
--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -99,6 +99,11 @@ spec:
                   - ipAddressPool
                   type: object
                 type: array
+              kubeconfigSecretName:
+                default: ""
+                description: Name of a secret that contains a kubeconfig. The kubeconfig
+                  is mounted under /var/lib/tempest/.kube/config in the test pod.
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -101,6 +101,7 @@ type TempestRunSpec struct {
         // If this option is specified then only tests that are part of
         // the external plugin can be executed.
         ExternalPlugin []ExternalPluginType `json:"externalPlugin,omitempty"`
+
 }
 
 // TempestSpec PythonTempestconf parts
@@ -285,7 +286,11 @@ type TempestSpec struct {
         // But can also be used to add additional files. Those get added to the service config dir in /etc/test_operator/<file>
         ConfigOverwrite map[string]string `json:"configOverwrite,omitempty"`
 
-	// TODO(slaweq): add more tempest run parameters here
+        // Name of a secret that contains a kubeconfig. The kubeconfig is mounted under /var/lib/tempest/.kube/config
+        // in the test pod.
+        // +kubebuilder:default:=""
+        // +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+        KubeconfigSecretName string `json:"kubeconfigSecretName,omitempty"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -99,6 +99,11 @@ spec:
                   - ipAddressPool
                   type: object
                 type: array
+              kubeconfigSecretName:
+                default: ""
+                description: Name of a secret that contains a kubeconfig. The kubeconfig
+                  is mounted under /var/lib/tempest/.kube/config in the test pod.
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -235,10 +235,15 @@ func (r *TempestReconciler) reconcileNormal(ctx context.Context, instance *testv
 		mountSSHKey = r.CheckSecretExists(ctx, instance, instance.Spec.SSHKeySecretName)
 	}
 
+	mountKubeconfig := false
+	if len(instance.Spec.KubeconfigSecretName) != 0 {
+		mountKubeconfig = true
+	}
+
 	// Create a new job
 	mountCerts := r.CheckSecretExists(ctx, instance, "combined-ca-bundle")
 	jobName := r.GetJobName(instance, 0)
-	jobDef := tempest.Job(instance, serviceLabels, jobName, mountCerts, mountSSHKey)
+	jobDef := tempest.Job(instance, serviceLabels, jobName, mountCerts, mountSSHKey, mountKubeconfig)
 	tempestJob := job.NewJob(
 		jobDef,
 		testv1beta1.ConfigHash,

--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -16,6 +16,7 @@ func Job(
 	jobName string,
 	mountCerts bool,
 	mountSSHKey bool,
+	mountKubeconfig bool,
 ) *batchv1.Job {
 
 	envVars := map[string]env.Setter{}
@@ -48,7 +49,7 @@ func Job(
 							Image:        instance.Spec.ContainerImage,
 							Args:         []string{},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: GetVolumeMounts(mountCerts, mountSSHKey),
+							VolumeMounts: GetVolumeMounts(mountCerts, mountSSHKey, mountKubeconfig),
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									ConfigMapRef: &corev1.ConfigMapEnvSource{
@@ -67,7 +68,7 @@ func Job(
 							},
 						},
 					},
-					Volumes: GetVolumes(mountCerts, mountSSHKey, instance),
+					Volumes: GetVolumes(mountCerts, mountSSHKey, mountKubeconfig, instance),
 				},
 			},
 		},

--- a/pkg/tempest/volumes.go
+++ b/pkg/tempest/volumes.go
@@ -6,7 +6,7 @@ import (
 )
 
 // GetVolumes -
-func GetVolumes(mountCerts bool, mountSSHKey bool, instance *testv1beta1.Tempest) []corev1.Volume {
+func GetVolumes(mountCerts bool, mountSSHKey bool, mountKubeconfig bool, instance *testv1beta1.Tempest) []corev1.Volume {
 
 	var scriptsVolumeDefaultMode int32 = 0755
 	var scriptsVolumeConfidentialMode int32 = 0420
@@ -105,11 +105,30 @@ func GetVolumes(mountCerts bool, mountSSHKey bool, instance *testv1beta1.Tempest
 		volumes = append(volumes, sshKeyVolume)
 	}
 
+	if mountKubeconfig {
+		kubeconfigVolume := corev1.Volume{
+			Name: "kubeconfig",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: instance.Spec.KubeconfigSecretName,
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "config",
+							Path: "config",
+						},
+					},
+				},
+			},
+		}
+
+		volumes = append(volumes, kubeconfigVolume)
+	}
+
 	return volumes
 }
 
 // GetVolumeMounts -
-func GetVolumeMounts(mountCerts bool, mountSSHKey bool) []corev1.VolumeMount {
+func GetVolumeMounts(mountCerts bool, mountSSHKey bool, mountKubeconfig bool) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "etc-machine-id",
@@ -164,6 +183,17 @@ func GetVolumeMounts(mountCerts bool, mountSSHKey bool) []corev1.VolumeMount {
 		}
 
 		volumeMounts = append(volumeMounts, sshKeyMount)
+	}
+
+	if mountKubeconfig {
+		kubeconfigMount := corev1.VolumeMount{
+			Name:      "kubeconfig",
+			MountPath: "/var/lib/tempest/.kube/config",
+			SubPath:   "config",
+			ReadOnly:  true,
+		}
+
+		volumeMounts = append(volumeMounts, kubeconfigMount)
 	}
 
 	return volumeMounts


### PR DESCRIPTION
This patch introduces KubeconfigSecretName parameter that can be used to mount kubeconfig to the tobiko test pod. The parameter accepts a name of a secret that contains the content of kubeconfig under "config" key value. The kubeconfig is mounted to
/var/lib/tempest/.kube/config

Depends-On: https://github.com/openstack-k8s-operators/tcib/pull/155