### PR TITLE
Run test-operator job only on main branch

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,6 +4,8 @@
     periodic:
       jobs:
         - podified-multinode-edpm-deployment-crc: &podified_multinode_edpm_deployment_crc
+            branches:
+              - main
             vars:
               cifmw_run_test_role: test_operator
               cifmw_run_tempest: true


### PR DESCRIPTION
Currently, the job is executed on all active branches in the test-operator repository. This takes away resources. Let's limit the job only to the main branch.

https://softwarefactory-project.io/zuul/t/rdoproject.org/builds?project=openstack-k8s-operators%2Ftest-operator&skip=0