### PR TITLE
Add variables for extra image creation

### DIFF
--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -101,6 +101,10 @@ type TempestRunSpec struct {
         // If this option is specified then only tests that are part of
         // the external plugin can be executed.
         ExternalPlugin []ExternalPluginType `json:"externalPlugin,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// Add extra image for Whitebox Neutron Tempest plugin
+	WhiteboxNeutronExtraImage string `json:"whiteboxNeutronExtraImage,omitempty"`
 }
 
 // TempestSpec PythonTempestconf parts

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -345,6 +345,11 @@ func (r *TempestReconciler) setTempestConfigVars(envVars map[string]string,
 		envVars["TEMPEST_EXCLUDE_LIST"] = testOperatorDir + excludeListFile
 	}
 
+	// String
+	if len(tempestRun.WhiteboxNeutronExtraImage) != 0 {
+		envVars["TEMPEST_WHITEBOX_NEUTRON_IMAGE_URL"] = tempestRun.WhiteboxNeutronExtraImage
+	}
+
 	// Bool
 	tempestBoolEnvVars := make(map[string]bool)
 	tempestBoolEnvVars = map[string]bool{

--- a/pkg/tempest/volumes.go
+++ b/pkg/tempest/volumes.go
@@ -138,6 +138,12 @@ func GetVolumeMounts(mountCerts bool, mountSSHKey bool) []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 		{
+			Name:      "openstack-config",
+			MountPath: "/var/lib/tempest/.config/openstack/clouds.yaml",
+			SubPath:   "clouds.yaml",
+			ReadOnly:  true,
+		},
+		{
 			Name:      "openstack-config-secret",
 			MountPath: "/etc/openstack/secure.yaml",
 			ReadOnly:  false,


### PR DESCRIPTION
This patch adds variables that work with tcib on adding extra image for advanced test in Whitebox Neutron Tempest plugin. By setting the new variable WhiteboxNeutronExtraImage, tcib downloads specified image and sets the right confinguration options to work with image for advaned tests.