### PR TITLE
[Tempest] Fix private key permissions

### DIFF
--- a/pkg/tempest/volumes.go
+++ b/pkg/tempest/volumes.go
@@ -11,6 +11,7 @@ func GetVolumes(mountCerts bool, mountSSHKey bool, instance *testv1beta1.Tempest
 	var scriptsVolumeDefaultMode int32 = 0755
 	var scriptsVolumeConfidentialMode int32 = 0420
 	var tlsCertificateMode int32 = 0444
+	var privateKeyMode int32 = 0600
 
 	//source_type := corev1.HostPathDirectoryOrCreate
 	volumes := []corev1.Volume{
@@ -91,7 +92,8 @@ func GetVolumes(mountCerts bool, mountSSHKey bool, instance *testv1beta1.Tempest
 			Name: "ssh-key",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: instance.Spec.SSHKeySecretName,
+					SecretName:  instance.Spec.SSHKeySecretName,
+					DefaultMode: &privateKeyMode,
 					Items: []corev1.KeyToPath{
 						{
 							Key:  "ssh-privatekey",
@@ -159,7 +161,7 @@ func GetVolumeMounts(mountCerts bool, mountSSHKey bool) []corev1.VolumeMount {
 	if mountSSHKey {
 		sshKeyMount := corev1.VolumeMount{
 			Name:      "ssh-key",
-			MountPath: "/var/lib/tempest/.ssh/id_ecdsa",
+			MountPath: "/var/lib/tempest/id_ecdsa",
 			SubPath:   "ssh_key",
 		}
 


### PR DESCRIPTION
This patch changes the mount destination for the private key. The reason for this change is to make it possible to change the permissions for the private key to 600.