### PR TITLE
Fix default value for storage class

### DIFF
--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -94,6 +94,7 @@ spec:
                   want to turn off this behaviour then set this option to true.
                 type: boolean
               storageClass:
+                default: local-storage
                 description: Name of a storage class that is used to create PVCs for
                   logs storage. Required if default storage class does not exist.
                 type: string

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -254,6 +254,7 @@ type TempestSpec struct {
 	SELinuxLevel string `json:"SELinuxLevel"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="local-storage"
 	// Name of a storage class that is used to create PVCs for logs storage. Required
 	// if default storage class does not exist.
 	StorageClass string `json:"storageClass"`

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -94,6 +94,7 @@ spec:
                   want to turn off this behaviour then set this option to true.
                 type: boolean
               storageClass:
+                default: local-storage
                 description: Name of a storage class that is used to create PVCs for
                   logs storage. Required if default storage class does not exist.
                 type: string


### PR DESCRIPTION
The storageClass option is missing a default value. Thanks to this the pvc sometimes does not get created if it is running an an environment that does not have a default storage class set.