### PR TITLE
Fix handling of NetworkAttachments in tempest controller

### DIFF
--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -13,6 +13,7 @@ import (
 func Job(
 	instance *testv1beta1.Tempest,
 	labels map[string]string,
+	annotations map[string]string,
 	jobName string,
 	envVarsConfigMapName string,
 	customDataConfigMapName string,
@@ -34,7 +35,8 @@ func Job(
 			BackoffLimit: instance.Spec.BackoffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Annotations: annotations,
+					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,


### PR DESCRIPTION
This patch fixes the usage of NetworkAttachments,
now it's possible to attach extra NICs to tempest
pods to allow egress traffic over secondary networks.

Resolves: OSPRH-6292