### PR TITLE
Add debug mode for test-operator

### DIFF
--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -277,6 +277,11 @@ type TempestSpec struct {
 	Parallel bool `json:"parallel,omitempty"`
 
 	// +kubebuilder:validation:Optional
+        // +kubebuilder:default=false
+        // Activate debug mode
+        Debug bool `json:"debug,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 

--- a/config/samples/test_v1beta1_tempest.yaml
+++ b/config/samples/test_v1beta1_tempest.yaml
@@ -8,6 +8,7 @@ spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-tempest:current-podified
   # storageClass: local-storage
   # parallel: false
+  # debug: false
 
   # configOverwrite
   # ---------------

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -561,6 +561,8 @@ func (r *TempestReconciler) generateServiceConfigMaps(
 	r.setTempestconfConfigVars(envVars, customData, instance, ctx, workflowStepNum)
 	r.setConfigOverwrite(customData, instance.Spec.ConfigOverwrite)
 
+	envVars["TEMPEST_DEBUG_MODE"] = r.GetDefaultBool(instance.Spec.Debug)
+
 	cms := []util.Template{
 		// ConfigMap
 		{


### PR DESCRIPTION
This patch introduces an option for test-operator that keeps the pod running even after a failure occured or after the file run_tempest.sh has reached its end (sleep infinity). It resolves the issue that oc rsh session is killed once the execution of the run_tempest.sh finishes.