### PR TITLE
Fix job being recreated

### DIFF
--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -273,7 +273,7 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	tempestJob := job.NewJob(
 		jobDef,
 		testv1beta1.ConfigHash,
-		false,
+		true,
 		time.Duration(5)*time.Second,
 		"",
 	)

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -195,7 +195,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	tobikoJob := job.NewJob(
 		jobDef,
 		testv1beta1.ConfigHash,
-		false,
+		true,
 		time.Duration(5)*time.Second,
 		"",
 	)


### PR DESCRIPTION
Let's change the created jobs by the test-operator to persistent ones. This prevents setting of TTL on jobs created by the test-operator and resolves the issue of jobs being recreated.