### PR TITLE
[zuul] Introduce github-check pipeline

### DIFF
--- a/.github/workflows/build-test-operator.yaml
+++ b/.github/workflows/build-test-operator.yaml
@@ -68,7 +68,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
 
     - name: Checkout test-operator repository
       uses: actions/checkout@v2

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,60 +1,85 @@
 ---
 - project:
     name: openstack-k8s-operators/test-operator
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider:
+            vars:
+              cifmw_operator_build_meta_build: false
+        - podified-multinode-edpm-deployment-crc-test-operator:
+            dependencies:
+              - openstack-k8s-operators-content-provider
     periodic:
       jobs:
-        - podified-multinode-edpm-deployment-crc: &podified_multinode_edpm_deployment_crc
-            branches:
-              - main
+        - openstack-k8s-operators-content-provider:
             vars:
-              cifmw_run_test_role: test_operator
-              cifmw_run_tempest: true
-              cifmw_test_operator_concurrency: 4
-              cifmw_test_operator_timeout: 7200
-              cifmw_test_operator_tempest_include_list: |
-                tempest.
-              cifmw_test_operator_tempest_exclude_list: |
-                tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_migration_with_trunk
-                tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
-                tempest.api.compute.servers.test_server_rescue.ServerStableDeviceRescueTestIDE
-                tempest.api.compute.servers.test_device_tagging
-                tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON
-                tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario
-                tempest.scenario.test_stamp_pattern
-                tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
-                tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
-                test_create_server_invalid_bdm_in_2nd_dict
-                tempest.api.identity.admin.v3.test_credentials.CredentialsTestJSON
-                tempest.api.identity.admin.v3.test_tokens.TokensV3TestJSON.test_rescope_token
-                tempest.api.identity.admin.v3.test_users.UsersV3TestJSON.test_update_user_password
-              cifmw_tempest_tempestconf_config:
-                overrides: |
-                  identity.v3_endpoint_type public
-                  service_available.swift false
-                  service_available.cinder false
-              cifmw_run_tobiko: true
-              cifmw_test_operator_tobiko_workflow:
-                - stepName: 'podified-functional'
-                  testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'
-                  numProcesses: 2
-                - stepName: 'sanity'
-                  testenv: 'sanity'
-            required-projects: &rp
-              - name: openstack-k8s-operators/install_yamls
-                override-checkout: main
-              - name: openstack-k8s-operators/openstack-operator
-                override-checkout: main
-              - name: github.com/openstack-k8s-operators/ci-framework
-                override-checkout: main
-              - name: github.com/openstack-k8s-operators/repo-setup
-                override-checkout: main
-              - name: github.com/openstack-k8s-operators/dataplane-operator
-                override-checkout: main
-              - name: github.com/openstack-k8s-operators/infra-operator
-                override-checkout: main
-              - name: github.com/openstack-k8s-operators/openstack-baremetal-operator
-                override-checkout: main
-              - name: github.com/openstack-k8s-operators/edpm-ansible
-                override-checkout: main
-              - name: github.com/openstack-k8s-operators/openstack-must-gather
-                override-checkout: main
+              cifmw_operator_build_meta_build: false
+        - podified-multinode-edpm-deployment-crc-test-operator:
+            dependencies:
+              - openstack-k8s-operators-content-provider
+
+- job:
+    name: podified-multinode-edpm-deployment-crc-test-operator
+    parent: podified-multinode-edpm-deployment-crc
+    branches:
+      - main
+    vars:
+      cifmw_install_yamls_whitelisted_vars:
+        - 'TEST_REPO'
+        - 'TEST_BRANCH'
+        - 'OUTPUT_DIR'
+
+      cifmw_run_test_role: test_operator
+      cifmw_test_operator_index: "{{ content_provider_registry_ip }}:5001/openstack-k8s-operators/test-operator-index:{{ zuul.patchset }}"
+
+      cifmw_run_tempest: true
+      cifmw_test_operator_concurrency: 4
+      cifmw_test_operator_timeout: 7200
+      cifmw_test_operator_tempest_include_list: |
+        ^tempest.
+      cifmw_test_operator_tempest_exclude_list: |
+        tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_migration_with_trunk
+        tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
+        tempest.api.compute.servers.test_server_rescue.ServerStableDeviceRescueTestIDE
+        tempest.api.compute.servers.test_device_tagging
+        tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON
+        tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario
+        tempest.scenario.test_stamp_pattern
+        tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
+        tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
+        test_create_server_invalid_bdm_in_2nd_dict
+        tempest.api.identity.admin.v3.test_credentials.CredentialsTestJSON
+        tempest.api.identity.admin.v3.test_tokens.TokensV3TestJSON.test_rescope_token
+        tempest.api.identity.admin.v3.test_users.UsersV3TestJSON.test_update_user_password
+      cifmw_tempest_tempestconf_config:
+        overrides: |
+          identity.v3_endpoint_type public
+          service_available.swift false
+          service_available.cinder false
+
+      cifmw_run_tobiko: true
+      cifmw_test_operator_tobiko_workflow:
+        - stepName: 'podified-functional'
+          testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'
+          numProcesses: 2
+        - stepName: 'sanity'
+          testenv: 'sanity'
+    required-projects: &rp
+      - name: openstack-k8s-operators/install_yamls
+        override-checkout: main
+      - name: openstack-k8s-operators/openstack-operator
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/ci-framework
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/repo-setup
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/dataplane-operator
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/infra-operator
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/openstack-baremetal-operator
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/edpm-ansible
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/openstack-must-gather
+        override-checkout: main

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GOLANG_BUILDER=golang:1.19
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.20
 ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM $GOLANG_BUILDER AS builder
@@ -17,6 +17,7 @@ ARG GO_BUILD_EXTRA_ARGS=
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
 WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
 
+USER root
 RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
 # cache deps before building and copying source so that we don't need to re-download as much

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/test-operator/api
 
-go 1.19
+go 1.20
 
 require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230523095909-db05945b0b1e

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/test-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
This patch introduces a github-check pipeline for the test-operator. The podified-multinode-edpm-deployment-crc-test-operator job consumes the test-operator built in the openstack-k8s-operators-content-provider job.