### PR TITLE
Fix tobiko logs dir name

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"crypto/sha256"
+
 	"github.com/go-logr/logr"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -83,10 +84,6 @@ func (r *Reconciler) GetJobName(instance interface{}, workflowStepNum int) strin
 
 func (r *Reconciler) GetWorkflowConfigMapName(instance client.Object) string {
 	return instance.GetName() + workflowNameSuffix
-}
-
-func (r *Reconciler) GetLogDirName(frameworkName string, instance client.Object, workflowStepNum int) string {
-	return frameworkName + "-" + instance.GetName() + logDirNameInfix + strconv.Itoa(workflowStepNum)
 }
 
 func (r *Reconciler) GetPVCLogsName(instance client.Object) string {

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -300,7 +300,7 @@ func (r *TobikoReconciler) PrepareTobikoEnvVars(
 	// Prepare env vars
 	envVars := make(map[string]env.Setter)
 	envVars["USE_EXTERNAL_FILES"] = env.SetValue("True")
-	envVars["TOBIKO_LOGS_DIR_NAME"] = env.SetValue(r.GetLogDirName("tobiko", instance, step))
+	envVars["TOBIKO_LOGS_DIR_NAME"] = env.SetValue(r.GetJobName(instance, step))
 	logging := log.FromContext(ctx)
 	logging.Info("STEP: " + strconv.Itoa(step))
 


### PR DESCRIPTION
This patch fixes the issue of tobiko logs dir not containing name of the step name when workflows are used.