### PR TITLE
Fix default concurrency value

### DIFF
--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: tempests.test.openstack.org
 spec:
@@ -104,7 +104,7 @@ spec:
                   for the further explanation of the CLI parameters.
                 properties:
                   concurrency:
-                    default: -1
+                    default: 0
                     description: Concurrency value that is passed to tempest via --concurrency
                     format: int64
                     type: integer

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -74,7 +74,7 @@ type TempestRunSpec struct {
 	ExcludeList string `json:"excludeList,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=-1
+	// +kubebuilder:default:=0
 	// Concurrency value that is passed to tempest via --concurrency
 	Concurrency int64 `json:"concurrency,omitempty"`
 

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: tempests.test.openstack.org
 spec:
@@ -104,7 +104,7 @@ spec:
                   for the further explanation of the CLI parameters.
                 properties:
                   concurrency:
-                    default: -1
+                    default: 0
                     description: Concurrency value that is passed to tempest via --concurrency
                     format: int64
                     type: integer


### PR DESCRIPTION
Recently we changed the default value of int parameters for the Tempest CR from -1 to 0. Unfortunately the concurrency value was left behind. This can cause a situation when tempest is executed with `--concurrency -1` when the user does not explicitly specify the concurrency in the Tempest CR.