### PR TITLE
Use RWX PVs only for parallel execution

### DIFF
--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -208,6 +208,7 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		helper,
 		serviceLabels,
 		instance.Spec.StorageClass,
+		instance.Spec.Parallel,
 	)
 
 	if err != nil {

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -152,6 +152,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		helper,
 		serviceLabels,
 		instance.Spec.StorageClass,
+		instance.Spec.Parallel,
 	)
 	if err != nil {
 		return ctrlResult, err


### PR DESCRIPTION
This change is needed as we are going to switch from local storage to LVMS based storage that does not support RWX. Because of that the test-operator will now be by default requesting RWO PVs only. RWX will be requested when parallel is set to true in the test-operator related CR.