### PR TITLE
[Tempest] Install extra RPMs

### DIFF
--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -211,6 +211,12 @@ spec:
                       - name
                       type: object
                     type: array
+                  extraRPMs:
+                    description: A list URLs that point to RPMs that should be downloaded
+                      and installed inside the tempest test pod.
+                    items:
+                      type: string
+                    type: array
                   includeList:
                     default: tempest.api.identity.v3
                     description: A content of include.txt file that is passed to tempest
@@ -593,6 +599,12 @@ spec:
                             - URL
                             - name
                             type: object
+                          type: array
+                        extraRPMs:
+                          description: A list URLs that point to RPMs that should
+                            be downloaded and installed inside the tempest test pod.
+                          items:
+                            type: string
                           type: array
                         includeList:
                           description: A content of include.txt file that is passed

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -170,6 +170,11 @@ type TempestRunSpec struct {
 	ExternalPlugin []ExternalPluginType `json:"externalPlugin,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// A list URLs that point to RPMs that should be downloaded and installed
+	// inside the tempest test pod.
+	ExtraRPMs []string `json:"extraRPMs,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// Extra images that should be downloaded inside the test pod and uploaded to
 	// openstack.
 	ExtraImages []ExtraImagesType `json:"extraImages"`

--- a/api/v1beta1/tempest_types_workflow.go
+++ b/api/v1beta1/tempest_types_workflow.go
@@ -59,6 +59,11 @@ type WorkflowTempestRunSpec struct {
 	ExternalPlugin *[]ExternalPluginType `json:"externalPlugin,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// A list URLs that point to RPMs that should be downloaded and installed
+	// inside the tempest test pod.
+	ExtraRPMs *[]string `json:"extraRPMs,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// Extra images that should be downloaded inside the test pod and uploaded to
 	// openstack.
 	ExtraImages *[]ExtraImagesType `json:"extraImagesType"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -155,6 +155,11 @@ func (in *TempestRunSpec) DeepCopyInto(out *TempestRunSpec) {
 		*out = make([]ExternalPluginType, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExtraRPMs != nil {
+		in, out := &in.ExtraRPMs, &out.ExtraRPMs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExtraImages != nil {
 		in, out := &in.ExtraImages, &out.ExtraImages
 		*out = make([]ExtraImagesType, len(*in))
@@ -526,6 +531,15 @@ func (in *WorkflowTempestRunSpec) DeepCopyInto(out *WorkflowTempestRunSpec) {
 		if **in != nil {
 			in, out := *in, *out
 			*out = make([]ExternalPluginType, len(*in))
+			copy(*out, *in)
+		}
+	}
+	if in.ExtraRPMs != nil {
+		in, out := &in.ExtraRPMs, &out.ExtraRPMs
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
 			copy(*out, *in)
 		}
 	}

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -211,6 +211,12 @@ spec:
                       - name
                       type: object
                     type: array
+                  extraRPMs:
+                    description: A list URLs that point to RPMs that should be downloaded
+                      and installed inside the tempest test pod.
+                    items:
+                      type: string
+                    type: array
                   includeList:
                     default: tempest.api.identity.v3
                     description: A content of include.txt file that is passed to tempest
@@ -593,6 +599,12 @@ spec:
                             - URL
                             - name
                             type: object
+                          type: array
+                        extraRPMs:
+                          description: A list URLs that point to RPMs that should
+                            be downloaded and installed inside the tempest test pod.
+                          items:
+                            type: string
                           type: array
                         includeList:
                           description: A content of include.txt file that is passed

--- a/config/samples/test_v1beta1_tempest.yaml
+++ b/config/samples/test_v1beta1_tempest.yaml
@@ -56,6 +56,16 @@ spec:
     #         RAM: 512
     #         disk: 20
     #         vcpus: 1
+
+    # extraRPMs:
+    # ----------
+    # A list of URLs that point to RPMs that should be installed before
+    # the execution of tempest. WARNING! This parameter has no efect when used
+    # in combination with externalPlugin parameter.
+    # extraRPMs:
+    #   - https://cbs.centos.org/kojifiles/packages/python-sshtunnel/0.4.0/12.el9s/noarch/python3-sshtunnel-0.4.0-12.el9s.noarch.rpm
+    #   - https://cbs.centos.org/kojifiles/packages/python-whitebox-tests-tempest/0.0.3/0.1.766ff04git.el9s/noarch/python3-whitebox-tests-tempest-0.0.3-0.1.766ff04git.el9s.noarch.rpm
+
   tempestconfRun:
     # NOTE: All parameters have default values (use only when you want to override
     #       the default behaviour)

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -460,6 +460,11 @@ func (r *TempestReconciler) setTempestConfigVars(envVars map[string]string,
 		envVars["TEMPEST_EXTRA_IMAGES_FLAVOR_DISK"] += r.GetDefaultInt(extraImageDict.Flavor.Disk, "-") + ","
 		envVars["TEMPEST_EXTRA_IMAGES_FLAVOR_VCPUS"] += r.GetDefaultInt(extraImageDict.Flavor.Vcpus, "-") + ","
 	}
+
+	extraRPMs := mergeWithWorkflow(tRun.ExtraRPMs, wtRun.ExtraRPMs)
+	for _, extraRPMURL := range extraRPMs {
+		envVars["TEMPEST_EXTRA_RPMS"] += extraRPMURL + ","
+	}
 }
 
 func mergeWithWorkflow[T any](value T, workflowValue *T) T {


### PR DESCRIPTION
This patch introduces tempestRun.extraRPMs parameter in the Tempest CR that allows to specifying a list of extra RPMs that should be installed before the execution of Tempest.

This parameter accepts a list of URLs that point to the RPMs that should be installed. The RPMs are installed in the order in which they are listed via the parameter.

Depends-On: https://github.com/openstack-k8s-operators/tcib/pull/175