### PR TITLE
Set default images

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -29,6 +29,7 @@ patchesStrategicMerge:
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
+- manager_default_images.yaml
 
 
 

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -1,0 +1,17 @@
+# This patch inject custom ENV settings to the manager container
+# Used to set our default image locations
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: RELATED_IMAGE_TEMPEST_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-tempest-all:current-podified
+        - name: RELATED_IMAGE_TOBIKO_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified


### PR DESCRIPTION
This patch ensures that two environment variables are set for the test-operator that contain the information about which images should be used for testing.