### PR TITLE
Change name of image env variables

### DIFF
--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: manager
         env:
-        - name: RELATED_IMAGE_TEMPEST_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_TEST_TEMPEST_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-tempest-all:current-podified
-        - name: RELATED_IMAGE_TOBIKO_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_TEST_TOBIKO_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified


### PR DESCRIPTION
The name of the env variables specifies name for variables in the openstackcontrolplane CR. It is more accurate to prefix these vars with Test to clearly indicate that these variables contain URLs that point to images that should be used for testing only.