### PR TITLE
Add --create when tempestConf section is empty

### DIFF
--- a/api/v1beta1/tempest_webhook.go
+++ b/api/v1beta1/tempest_webhook.go
@@ -63,6 +63,10 @@ func (spec *TempestSpec) Default() {
         if spec.ContainerImage == "" {
 		spec.ContainerImage = tempestDefaults.ContainerImageURL
 	}
+
+	if spec.TempestconfRun == (TempestconfRunSpec{}) {
+		spec.TempestconfRun.Create = true
+	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/hack/clean_local_webhook.sh
+++ b/hack/clean_local_webhook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+oc delete validatingwebhookconfiguration/vtempest.kb.io --ignore-not-found
+oc delete mutatingwebhookconfiguration/mtempest.kb.io --ignore-not-found

--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -35,13 +35,41 @@ cat >> ${TMPDIR}/patch_webhook_configurations.yaml <<EOF_CAT
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: mtempest.kb.io
+  name: vtempest.kb.io
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     caBundle: ${CA_BUNDLE}
     url: https://${CRC_IP}:9443/validate-test-openstack-org-v1beta1-tempest
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vtempest.kb.io
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - test.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tempests
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mtempest.kb.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: ${CA_BUNDLE}
+    url: https://${CRC_IP}:9443/mutate-test-openstack-org-v1beta1-tempest
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: mtempest.kb.io
@@ -61,4 +89,4 @@ webhooks:
   timeoutSeconds: 10
 EOF_CAT
 
-/home/cloud-user/.crc/cache/crc_libvirt_4.14.7_amd64/oc apply -n openstack -f ${TMPDIR}/patch_webhook_configurations.yaml
+oc apply -n openstack -f ${TMPDIR}/patch_webhook_configurations.yaml


### PR DESCRIPTION
When tempestConf section is empty in Tempest CR the default value for create is set to false, which leads to discover-tempest-config failure, even though the CR is valid. This patch sets create to true if the tempestConf section is empty to prevent the failure.

Additionally, this patch corrects local configuration of webhooks as this patch works with mutating webhook and needs these changes to work properly.