### PR TITLE
Add correct labels

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    openstack.org/operator-name: test-operator
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
@@ -18,6 +19,7 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
+    openstack.org/operator-name: test-operator
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
@@ -27,7 +29,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      openstack.org/operator-name: test-operator
   replicas: 1
   template:
     metadata:
@@ -35,6 +37,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        openstack.org/operator-name: test-operator
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution. 

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -23,4 +23,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      openstack.org/operator-name: test-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -18,4 +18,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    openstack.org/operator-name: test-operator

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -17,4 +17,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    openstack.org/operator-name: test-operator


### PR DESCRIPTION
This patch ensures that resources related to the test-operator are created with the `openstack.org/operator-name: test-operator` label. This fixes the webhook issue as the service created for the webhook was matching all the operators with
the `control-plane: controller-manager` label.