### PR TITLE
[zuul] Disable tobiko testing

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -23,8 +23,6 @@
 - job:
     name: podified-multinode-edpm-deployment-crc-test-operator
     parent: podified-multinode-edpm-deployment-crc
-    branches:
-      - main
     vars:
       cifmw_install_yamls_whitelisted_vars:
         - 'TEST_REPO'
@@ -73,7 +71,9 @@
             vcpus: 1
       cifmw_test_operator_tempest_ntp_extra_images: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
 
-      cifmw_run_tobiko: true
+      # NOTE(lpiwowar): Change to true once this fix fully propagates into the latest build of the tobiko image
+      # https://review.opendev.org/c/x/tobiko/+/922184
+      cifmw_run_tobiko: false
       cifmw_test_operator_tobiko_workflow:
         - stepName: 'podified-functional'
           testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'


### PR DESCRIPTION
Let's disable tobiko testing in the check job for now as there is a numpy
related bug in tobiko that should be fixed with this PR [1]. We can
enable tobiko testing again once the change fully propagates into the
tobiko image.

[1] https://review.opendev.org/c/x/tobiko/+/922184