### PR TITLE
Add link to guide video to the documentation

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -24,6 +24,10 @@ This guide describes:
 If you want to get your hands on the test-operator quickly, then follow these two
 sections: :ref:`running-operator-olm` and :ref:`executing-tests`.
 
+.. note::
+  If you prefer visual guides, you can check out
+  `Test Operator Tempest Guide <https://www.youtube.com/watch?v=nz72z5goEP8>`_ video.
+
 .. _running-operator-olm:
 
 Running Test Operator Using the Operator Lifecycle Manager (OLM)


### PR DESCRIPTION
This patch adds a new note to the test operator documentation that contains link to a visual guide for problems user can encounter with Tempest.