### PR TITLE
Request separate PVCs when parallel is set to true

### DIFF
--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -166,7 +166,7 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		helper,
 		serviceLabels,
 		instance.Spec.StorageClass,
-		false,
+		0,
 	)
 	if err != nil {
 		return ctrlResult, err
@@ -202,7 +202,7 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	mountCerts := r.CheckSecretExists(ctx, instance, "combined-ca-bundle")
 	jobName := r.GetJobName(instance, externalWorkflowCounter)
 	envVars, workflowOverrideParams := r.PrepareAnsibleEnv(ctx, serviceLabels, instance, helper, externalWorkflowCounter)
-	logsPVCName := r.GetPVCLogsName(instance)
+	logsPVCName := r.GetPVCLogsName(instance, 0)
 	containerImage := r.GetContainerImage(ctx, helper, workflowOverrideParams["ContainerImage"], instance)
 	jobDef := ansibletest.Job(
 		instance,

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -133,7 +133,7 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		helper,
 		serviceLabels,
 		instance.Spec.StorageClass,
-		instance.Spec.Parallel,
+		0,
 	)
 	if err != nil {
 		return ctrlResult, err
@@ -168,7 +168,7 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Prepare HorizonTest env vars
 	envVars := r.PrepareHorizonTestEnvVars(ctx, serviceLabels, instance, helper)
 	jobName := r.GetJobName(instance, 0)
-	logsPVCName := r.GetPVCLogsName(instance)
+	logsPVCName := r.GetPVCLogsName(instance, 0)
 	containerImage := r.GetContainerImage(ctx, helper, instance.Spec.ContainerImage, instance)
 	jobDef := horizontest.Job(
 		instance,


### PR DESCRIPTION
This patch changes the way PVCs are requested when the parallel option is set to true. Instead of using one PV for all the workflow steps, it is divided into multiple PVs. This change is needed, because the LVM backed storage does not support the RWX, which causes issues in some cases.