### PR TITLE
Remove explicit reference to upstream image

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -76,7 +76,7 @@ spec:
                   in the ansible pod
                 type: string
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified
+                default: ""
                 description: Container image for AnsibleTest
                 type: string
               debug:

--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -55,7 +55,7 @@ spec:
                 format: int32
                 type: integer
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
+                default: ""
                 description: Container image for horizontest
                 type: string
               dashboardUrl:

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -46,7 +46,7 @@ spec:
                 description: tobiko.conf
                 type: string
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
+                default: ""
                 description: Container image for tobiko
                 type: string
               debug:

--- a/api/v1beta1/ansibletest_types.go
+++ b/api/v1beta1/ansibletest_types.go
@@ -125,7 +125,7 @@ type AnsibleTestSpec struct {
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified"
+	// +kubebuilder:default:=""
 	// Container image for AnsibleTest
 	ContainerImage string `json:"containerImage,omitempty"`
 

--- a/api/v1beta1/horizontest_types.go
+++ b/api/v1beta1/horizontest_types.go
@@ -110,7 +110,7 @@ type HorizonTestSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="quay.io/podified-antelope-centos9/openstack-horizontest:current-podified"
+	// +kubebuilder:default:=""
 	// Container image for horizontest
 	ContainerImage string `json:"containerImage,omitempty"`
 

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -111,7 +111,7 @@ type TobikoSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-        // +kubebuilder:default:="quay.io/podified-antelope-centos9/openstack-tobiko:current-podified"
+        // +kubebuilder:default:=""
         // Container image for tobiko
         ContainerImage string `json:"containerImage,omitempty"`
 

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -76,7 +76,7 @@ spec:
                   in the ansible pod
                 type: string
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-ansible-tests:current-podified
+                default: ""
                 description: Container image for AnsibleTest
                 type: string
               debug:

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -55,7 +55,7 @@ spec:
                 format: int32
                 type: integer
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
+                default: ""
                 description: Container image for horizontest
                 type: string
               dashboardUrl:

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -46,7 +46,7 @@ spec:
                 description: tobiko.conf
                 type: string
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
+                default: ""
                 description: Container image for tobiko
                 type: string
               debug:

--- a/config/samples/test_v1beta1_horizontest.yaml
+++ b/config/samples/test_v1beta1_horizontest.yaml
@@ -10,7 +10,7 @@ metadata:
   name: horizontest-sample
 spec:
   spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-horizontest:current-podified
+  containerImage: ""
 
   # OpenStack admin credentials
   adminUsername: "admin"
@@ -54,4 +54,4 @@ spec:
 
   # The maximum number of retry executions (optional)
   backoffLimit: 0
- 
+

--- a/config/samples/test_v1beta1_tempest.yaml
+++ b/config/samples/test_v1beta1_tempest.yaml
@@ -5,7 +5,7 @@ metadata:
   name: tempest-tests
   namespace: openstack
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-tempest:current-podified
+  containerImage: ""
   # storageClass: local-storage
   # parallel: false
   # debug: false

--- a/config/samples/test_v1beta1_tobiko.yaml
+++ b/config/samples/test_v1beta1_tobiko.yaml
@@ -5,7 +5,7 @@ metadata:
   name: tobiko-tests
   namespace: openstack
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-tobiko:current-podified
+  containerImage: ""
   # storageClass: local-storage
   # parallel: false
   # privateKey: |


### PR DESCRIPTION
We should not be hardcoding references to upstream images in the CRs. Images that should be used by the operator should be listed in the manager_default_images.yaml.