### PR TITLE
Adding patch rbac perm for serviceaccounts

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,6 +36,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -97,6 +98,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -107,6 +109,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -135,6 +138,7 @@ rules:
   resources:
   - ansibletests/finalizers
   verbs:
+  - patch
   - update
 - apiGroups:
   - test.openstack.org
@@ -161,6 +165,7 @@ rules:
   resources:
   - horizontests/finalizers
   verbs:
+  - patch
   - update
 - apiGroups:
   - test.openstack.org
@@ -187,6 +192,7 @@ rules:
   resources:
   - tempests/finalizers
   verbs:
+  - patch
   - update
 - apiGroups:
   - test.openstack.org
@@ -213,6 +219,7 @@ rules:
   resources:
   - tobikoes/finalizers
   verbs:
+  - patch
   - update
 - apiGroups:
   - test.openstack.org

--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -47,7 +47,7 @@ type AnsibleTestReconciler struct {
 
 // +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests/finalizers,verbs=update
+// +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests/finalizers,verbs=update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
@@ -55,9 +55,9 @@ type AnsibleTestReconciler struct {
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
 
 // service account, role, rolebinding
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -47,7 +47,7 @@ type HorizonTestReconciler struct {
 
 //+kubebuilder:rbac:groups=test.openstack.org,resources=horizontests,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/finalizers,verbs=update
+//+kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/finalizers,verbs=update;patch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch
 

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -49,7 +49,7 @@ type TempestReconciler struct {
 
 // +kubebuilder:rbac:groups=test.openstack.org,resources=tempests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/finalizers,verbs=update
+// +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/finalizers,verbs=update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
@@ -57,9 +57,9 @@ type TempestReconciler struct {
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
 
 // service account, role, rolebinding
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -48,7 +48,7 @@ type TobikoReconciler struct {
 
 //+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/finalizers,verbs=update
+//+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/finalizers,verbs=update;patch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch
 


### PR DESCRIPTION
We also took the opportunity and added patch to all the existing rbac rules that had update already to avoid similar issues in the future

Resolves: https://issues.redhat.com/browse/OSPRH-8363