### PR TITLE
Fix panic:interface conversion

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -71,9 +71,7 @@
             vcpus: 1
       cifmw_test_operator_tempest_ntp_extra_images: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
 
-      # NOTE(lpiwowar): Change to true once this fix fully propagates into the latest build of the tobiko image
-      # https://review.opendev.org/c/x/tobiko/+/922184
-      cifmw_run_tobiko: false
+      cifmw_run_tobiko: true
       cifmw_test_operator_tobiko_workflow:
         - stepName: 'podified-functional'
           testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -218,16 +218,16 @@ func (r *HorizonTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // password value is missing in the clouds.yaml
 func (r *HorizonTestReconciler) EnsureHorizonTestCloudsYAML(ctx context.Context, instance client.Object, helper *helper.Helper, labels map[string]string) (ctrl.Result, error) {
 	cm, _, _ := configmap.GetConfigMap(ctx, helper, instance, "openstack-config", time.Second*10)
-	result := make(map[interface{}]interface{})
+	result := make(map[string]interface{})
 
 	err := yaml.Unmarshal([]byte(cm.Data["clouds.yaml"]), &result)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	clouds := result["clouds"].(map[interface{}]interface{})
-	default_value := clouds["default"].(map[interface{}]interface{})
-	auth := default_value["auth"].(map[interface{}]interface{})
+	clouds := result["clouds"].(map[string]interface{})
+	default_value := clouds["default"].(map[string]interface{})
+	auth := default_value["auth"].(map[string]interface{})
 
 	if _, ok := auth["password"].(string); !ok {
 		auth["password"] = "12345678"

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -255,16 +255,16 @@ func (r *TobikoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // password value is missing in the clouds.yaml
 func (r *TobikoReconciler) EnsureTobikoCloudsYAML(ctx context.Context, instance client.Object, helper *helper.Helper, labels map[string]string) (ctrl.Result, error) {
 	cm, _, _ := configmap.GetConfigMap(ctx, helper, instance, "openstack-config", time.Second*10)
-	result := make(map[interface{}]interface{})
+	result := make(map[string]interface{})
 
 	err := yaml.Unmarshal([]byte(cm.Data["clouds.yaml"]), &result)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	clouds := result["clouds"].(map[interface{}]interface{})
-	default_value := clouds["default"].(map[interface{}]interface{})
-	auth := default_value["auth"].(map[interface{}]interface{})
+	clouds := result["clouds"].(map[string]interface{})
+	default_value := clouds["default"].(map[string]interface{})
+	auth := default_value["auth"].(map[string]interface{})
 
 	if _, ok := auth["password"].(string); !ok {
 		auth["password"] = "12345678"


### PR DESCRIPTION
This fixes the following error:
panic: interface conversion: interface {} is map[string]interface {}, not map[interface {}]interface {} [recovered]