### PR TITLE
Fix wrong descriptions for Tobiko CR options

### DIFF
--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -49,10 +49,6 @@ spec:
                 default: ""
                 description: Container image for tobiko
                 type: string
-              debug:
-                default: true
-                description: Run tests in parallel
-                type: boolean
               kubeconfigSecretName:
                 default: ""
                 description: Name of a secret that contains a kubeconfig. The kubeconfig
@@ -71,7 +67,9 @@ spec:
                 type: integer
               parallel:
                 default: false
-                description: Container image for tobiko
+                description: By default test-operator executes the test-pods sequentially
+                  if multiple instances of test-operator related CRs exist. To run
+                  test-pods in parallel set this option to true.
                 type: boolean
               preventCreate:
                 default: false
@@ -159,9 +157,6 @@ spec:
                     containerImage:
                       description: Container image for tobiko
                       type: string
-                    debug:
-                      description: Run tests in parallel
-                      type: boolean
                     kubeconfigSecretName:
                       description: Name of a secret that contains a kubeconfig. The
                         kubeconfig is mounted under /var/lib/tobiko/.kube/config in

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -57,12 +57,6 @@ type TobikoSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-        // +kubebuilder:default:=true
-        // Run tests in parallel
-        Debug bool `json:"debug,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
         // +kubebuilder:default:="py3"
         // Test environment
         Testenv string `json:"testenv,omitempty"`
@@ -118,7 +112,9 @@ type TobikoSpec struct {
         // +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
         // +kubebuilder:default:=false
-        // Container image for tobiko
+	// By default test-operator executes the test-pods sequentially if multiple
+	// instances of test-operator related CRs exist. To run test-pods in parallel
+	// set this option to true.
         Parallel bool `json:"parallel,omitempty"`
 
 	// BackoffLimimt allows to define the maximum number of retried executions (defaults to 6).
@@ -158,11 +154,6 @@ type TobikoWorkflowSpec struct {
 	// This value contains a toleration that is applied to pods spawned by the
 	// test pods that are spawned by the test-operator.
 	Tolerations *[]corev1.Toleration `json:"tolerations,omitempty"`
-
-        // +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-        // Run tests in parallel
-        Debug bool `json:"debug,omitempty"`
 
         // +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -49,10 +49,6 @@ spec:
                 default: ""
                 description: Container image for tobiko
                 type: string
-              debug:
-                default: true
-                description: Run tests in parallel
-                type: boolean
               kubeconfigSecretName:
                 default: ""
                 description: Name of a secret that contains a kubeconfig. The kubeconfig
@@ -71,7 +67,9 @@ spec:
                 type: integer
               parallel:
                 default: false
-                description: Container image for tobiko
+                description: By default test-operator executes the test-pods sequentially
+                  if multiple instances of test-operator related CRs exist. To run
+                  test-pods in parallel set this option to true.
                 type: boolean
               preventCreate:
                 default: false
@@ -159,9 +157,6 @@ spec:
                     containerImage:
                       description: Container image for tobiko
                       type: string
-                    debug:
-                      description: Run tests in parallel
-                      type: boolean
                     kubeconfigSecretName:
                       description: Name of a secret that contains a kubeconfig. The
                         kubeconfig is mounted under /var/lib/tobiko/.kube/config in


### PR DESCRIPTION
Some Tobiko CR options have wrongly copy-pasted descriptions. This patch adds correct descriptions to fix this issue.