### PR TITLE
Add networkAttachments into test-operator CSV

### DIFF
--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -58,18 +58,18 @@ spec:
                 description: Name of a secret that contains a kubeconfig. The kubeconfig
                   is mounted under /var/lib/tobiko/.kube/config in the test pod.
                 type: string
-              nodeSelector:
-                additionalProperties:
-                  type: string
-                description: This value contains a nodeSelector value that is applied
-                  to test pods spawned by the test operator.
-                type: object
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network
                 items:
                   type: string
                 type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: This value contains a nodeSelector value that is applied
+                  to test pods spawned by the test operator.
+                type: object
               numProcesses:
                 default: 0
                 description: Number of processes/workers used to run tobiko tests

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -591,6 +591,10 @@ spec:
         path: kubeconfigSecretName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: NetworkAttachments is a list of NetworkAttachment resource names
+          to expose the services to the given network
+        displayName: Network Attachments
+        path: networkAttachments
       - description: This value contains a nodeSelector value that is applied to test
           pods spawned by the test operator.
         displayName: Node Selector
@@ -655,6 +659,10 @@ spec:
         path: workflow[0].kubeconfigSecretName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: NetworkAttachments is a list of NetworkAttachment resource names
+          to expose the services to the given network
+        displayName: Network Attachments
+        path: workflow[0].networkAttachments
       - description: This value contains a nodeSelector value that is applied to test
           pods spawned by the test operator.
         displayName: Node Selector


### PR DESCRIPTION
This PR [1] introduced a new parameter for the Tobiko CR (networkAttachments). Let's mention this parameter in the test-operator CSV as well.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/134