### PR TITLE
Extend zz_generated.deepcopy.go with networkAttachments

### DIFF
--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -690,6 +690,11 @@ func (in *TobikoSpec) DeepCopyInto(out *TobikoSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.NetworkAttachments != nil {
+		in, out := &in.NetworkAttachments, &out.NetworkAttachments
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Workflow != nil {
 		in, out := &in.Workflow, &out.Workflow
 		*out = make([]TobikoWorkflowSpec, len(*in))
@@ -787,6 +792,11 @@ func (in *TobikoWorkflowSpec) DeepCopyInto(out *TobikoWorkflowSpec) {
 		in, out := &in.NumProcesses, &out.NumProcesses
 		*out = new(uint8)
 		**out = **in
+	}
+	if in.NetworkAttachments != nil {
+		in, out := &in.NetworkAttachments, &out.NetworkAttachments
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.BackoffLimit != nil {
 		in, out := &in.BackoffLimit, &out.BackoffLimit


### PR DESCRIPTION
This PR introduced networkAttachments [1] for Tobiko CR but did not extend the manually generated code by running `make generate`. This PR fixes that.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/134