### PR TITLE
Add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "extends": [
+    "github>openstack-k8s-operators/renovate-config:default.json5"
+  ],
+  "baseBranches": ["main"],
+  "useBaseBranchConfig": "merge",
+  "packageRules": [
+    {
+      "matchPackageNames": ["github.com/openstack-k8s-operators/test-operator/api"],
+      "enabled": false
+    }
+  ],
+  "postUpgradeTasks": {
+    "commands": ["make gowork", "make tidy", "make manifests generate"],
+    "fileFilters": ["**/go.mod", "**/go.sum", "**/*.go", "**/*.yaml"],
+    "executionMode": "update"
+  }
+}


### PR DESCRIPTION
Adds config to regularly use renovate auto open PRs for dependency bumps.