### PR TITLE
FIPS compliant images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
 ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.20
-ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 FROM $GOLANG_BUILDER AS builder
 
@@ -12,7 +12,8 @@ ARG REMOTE_SOURCE_DIR=/remote-source
 ARG REMOTE_SOURCE_SUBDIR=
 ARG DEST_ROOT=/dest-root
 
-ARG GO_BUILD_EXTRA_ARGS=
+ARG GO_BUILD_EXTRA_ARGS="-tags strictfipsruntime"
+ARG GO_BUILD_EXTRA_ENV_ARGS="CGO_ENABLED=1 GO111MODULE=on"
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
 WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
@@ -25,7 +26,7 @@ RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
 
 # Build manager
-RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; env ${GO_BUILD_EXTRA_ENV_ARGS} go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
 
 RUN cp -r templates ${DEST_ROOT}/templates
 
@@ -50,16 +51,16 @@ ARG IMAGE_TAGS="cn-openstack openstack"
 
 # Labels required by upstream and osbs build system
 LABEL com.redhat.component="${IMAGE_COMPONENT}" \
-      name="${IMAGE_NAME}" \
-      version="${IMAGE_VERSION}" \
-      summary="${IMAGE_SUMMARY}" \
-      io.k8s.name="${IMAGE_NAME}" \
-      io.k8s.description="${IMAGE_DESC}" \
-      io.openshift.tags="${IMAGE_TAGS}"
+	name="${IMAGE_NAME}" \
+	version="${IMAGE_VERSION}" \
+	summary="${IMAGE_SUMMARY}" \
+	io.k8s.name="${IMAGE_NAME}" \
+	io.k8s.description="${IMAGE_DESC}" \
+	io.openshift.tags="${IMAGE_TAGS}"
 ### DO NOT EDIT LINES ABOVE
 
 ENV USER_UID=$USER_ID \
-    OPERATOR_TEMPLATES=/usr/share/test-operator/templates/
+	OPERATOR_TEMPLATES=/usr/share/test-operator/templates/
 
 WORKDIR /
 


### PR DESCRIPTION
- Changed the base image to ubi9/minimal
- Added the default GO_BUILD_EXTRA_ARGS="-tags strictfipsruntime"
- Added the GO_BUILD_EXTRA_ENV_ARGS build argument to allow custom build arguments at build time. It defaults to "CGO_ENABLED=1 GO111MODULE=on"
- Those default parameters have been added to enable FIPS compliance
- Fixed indentation

Related: https://issues.redhat.com/browse/OSPRH-8910