### PR TITLE
Add debug mode for Tobiko

### DIFF
--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -49,6 +49,14 @@ spec:
                 default: ""
                 description: Container image for tobiko
                 type: string
+              debug:
+                default: false
+                description: Activate debug mode. When debug mode is activated any
+                  error encountered inside the test-pod causes that the pod will be
+                  kept alive indefinitely (stuck in "Running" phase) or until the
+                  corresponding Tobiko CR is deleted. This allows the user to debug
+                  any potential troubles with `oc rsh`.
+                type: boolean
               kubeconfigSecretName:
                 default: ""
                 description: Name of a secret that contains a kubeconfig. The kubeconfig

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -50,6 +50,14 @@ type TobikoSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+        // +kubebuilder:default=false
+        // Activate debug mode. When debug mode is activated any error encountered
+        // inside the test-pod causes that the pod will be kept alive indefinitely
+        // (stuck in "Running" phase) or until the corresponding Tobiko CR is deleted.
+        // This allows the user to debug any potential troubles with `oc rsh`.
+        Debug bool `json:"debug,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// This value contains a toleration that is applied to pods spawned by the
 	// test pods that are spawned by the test-operator.

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -49,6 +49,14 @@ spec:
                 default: ""
                 description: Container image for tobiko
                 type: string
+              debug:
+                default: false
+                description: Activate debug mode. When debug mode is activated any
+                  error encountered inside the test-pod causes that the pod will be
+                  kept alive indefinitely (stuck in "Running" phase) or until the
+                  corresponding Tobiko CR is deleted. This allows the user to debug
+                  any potential troubles with `oc rsh`.
+                type: boolean
               kubeconfigSecretName:
                 default: ""
                 description: Name of a secret that contains a kubeconfig. The kubeconfig

--- a/config/samples/test_v1beta1_tobiko.yaml
+++ b/config/samples/test_v1beta1_tobiko.yaml
@@ -8,6 +8,7 @@ spec:
   containerImage: ""
   # storageClass: local-storage
   # parallel: false
+  # debug: false
   # privateKey: |
   #   <private-key-value>
   # publicKey: |

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -381,6 +381,7 @@ func (r *TobikoReconciler) PrepareTobikoEnvVars(
 	}
 
 	envVars["TOBIKO_KEYS_FOLDER"] = env.SetValue("/etc/test_operator")
+	envVars["TOBIKO_DEBUG_MODE"] = env.SetValue(r.GetDefaultBool(instance.Spec.Debug))
 	// Prepare env vars - end
 
 	// Prepare custom data


### PR DESCRIPTION
Similar to debug mode for Tempest, this patch introduces new option for test-operator that keeps the pod running after a successful run or even after a failure has occured. It resolves the issue that oc rsh session is killed once the execution of the run_tobiko.sh file finishes.