### PR TITLE
Protect lock from deletion by different reconcile loop

### DIFF
--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -120,7 +120,9 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// The job created by the instance was completed. Release the lock
 		// so that other instances can spawn a job.
 		logging.Info("Job completed")
-		r.ReleaseLock(ctx, instance)
+		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Service account, role, binding
@@ -184,10 +186,11 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// We are about to start job that spawns the pod with tests.
 	// This lock ensures that there is always only one pod running.
-	if !r.AcquireLock(ctx, instance, helper, false) {
+	lockAcquired, err := r.AcquireLock(ctx, instance, helper, false)
+	if !lockAcquired {
 		logging.Info("Can not acquire lock")
 		requeueAfter := time.Second * 60
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 	logging.Info("Lock acquired")
 
@@ -231,7 +234,10 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// Creation of the ansibleTests job was not successfull.
 		// Release the lock and allow other controllers to spawn
 		// a job.
-		r.ReleaseLock(ctx, instance)
+		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
+			return ctrl.Result{}, err
+		}
+
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.ErrorReason,

--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"reflect"
 
+	"github.com/go-logr/logr"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -45,6 +46,11 @@ type AnsibleTestReconciler struct {
 	Reconciler
 }
 
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
+func (r *AnsibleTestReconciler) GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("Tobiko")
+}
+
 // +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests/finalizers,verbs=update;patch
@@ -65,6 +71,7 @@ type AnsibleTestReconciler struct {
 
 // Reconcile - AnsibleTestReconciler
 func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
+	Log := r.GetLogger(ctx)
 
 	// How much time should we wait before calling Reconcile loop when there is a failure
 	requeueAfter := time.Second * 60
@@ -115,11 +122,10 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		currentWorkflowStep, _ = strconv.Atoi(runningAnsibleJob.Labels["workflowStep"])
 	}
 
-	logging := log.FromContext(ctx)
 	if r.CompletedJobExists(ctx, instance, currentWorkflowStep) {
 		// The job created by the instance was completed. Release the lock
 		// so that other instances can spawn a job.
-		logging.Info("Job completed")
+		Log.Info("Job completed")
 		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
 			return ctrl.Result{}, err
 		}
@@ -188,11 +194,11 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// This lock ensures that there is always only one pod running.
 	lockAcquired, err := r.AcquireLock(ctx, instance, helper, false)
 	if !lockAcquired {
-		logging.Info("Can not acquire lock")
+		Log.Info("Can not acquire lock")
 		requeueAfter := time.Second * 60
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
-	logging.Info("Lock acquired")
+	Log.Info("Lock acquired")
 
 	if workflowActive {
 		r.WorkflowStepCounterIncrease(ctx, instance, helper)
@@ -255,7 +261,7 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	// Create a new job - end
 
-	r.Log.Info("Reconciled Service successfully")
+	Log.Info("Reconciled Service successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -159,9 +159,10 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// We are about to start job that spawns the pod with tests.
 	// This lock ensures that there is always only one pod running.
-	if !r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel) {
+	lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
+	if !lockAcquired {
 		logging.Info("Cannot acquire lock")
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 	logging.Info("Lock acquired")
 

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
@@ -47,6 +48,11 @@ type TempestReconciler struct {
 	Reconciler
 }
 
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
+func (r *TempestReconciler) GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("Tempest")
+}
+
 // +kubebuilder:rbac:groups=test.openstack.org,resources=tempests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/finalizers,verbs=update;patch
@@ -67,7 +73,7 @@ type TempestReconciler struct {
 
 // Reconcile - Tempest
 func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	_ = r.Log.WithValues("tempest", req.NamespacedName)
+	Log := r.GetLogger(ctx)
 
 	// How much time should we wait before calling Reconcile loop when there is a failure
 	requeueAfter := time.Second * 60
@@ -116,11 +122,10 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		currentWorkflowStep, _ = strconv.Atoi(runningTobikoJob.Labels["workflowStep"])
 	}
 
-	logging := log.FromContext(ctx)
 	if r.CompletedJobExists(ctx, instance, currentWorkflowStep) {
 		// The job created by the instance was completed. Release the lock
 		// so that other instances can spawn a job.
-		logging.Info("Job completed")
+		Log.Info("Job completed")
 		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
 			return ctrl.Result{}, err
 		}
@@ -165,7 +170,7 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(instance, helper)
+		return r.reconcileDelete(ctx, instance, helper)
 	}
 
 	// Service account, role, binding
@@ -243,11 +248,11 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// This lock ensures that there is always only one pod running.
 	lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
 	if !lockAcquired {
-		logging.Info("Can not acquire lock")
+		Log.Info("Can not acquire lock")
 		requeueAfter := time.Second * 60
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
-	logging.Info("Lock acquired")
+	Log.Info("Lock acquired")
 
 	if workflowActive {
 		r.WorkflowStepCounterIncrease(ctx, instance, helper)
@@ -362,20 +367,22 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}
 	// NetworkAttachments - end
 
-	r.Log.Info("Reconciled Service successfully")
+	Log.Info("Reconciled Service successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *TempestReconciler) reconcileDelete(
+	ctx context.Context,
 	instance *testv1beta1.Tempest,
 	helper *helper.Helper,
 ) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service delete")
+	Log := r.GetLogger(ctx)
+	Log.Info("Reconciling Service delete")
 
 	// remove the finalizer
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 
-	r.Log.Info("Reconciled Service delete successfully")
+	Log.Info("Reconciled Service delete successfully")
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -121,7 +121,9 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		// The job created by the instance was completed. Release the lock
 		// so that other instances can spawn a job.
 		logging.Info("Job completed")
-		r.ReleaseLock(ctx, instance)
+		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Always patch the instance status when exiting this function so we
@@ -239,10 +241,11 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// We are about to start job that spawns the pod with tests.
 	// This lock ensures that there is always only one pod running.
-	if !r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel) {
+	lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
+	if !lockAcquired {
 		logging.Info("Can not acquire lock")
 		requeueAfter := time.Second * 60
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 	logging.Info("Lock acquired")
 
@@ -317,7 +320,10 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		// Creation of the tempest job was not successfull.
 		// Release the lock and allow other controllers to spawn
 		// a job.
-		r.ReleaseLock(ctx, instance)
+		if lockReleased, lockErr := r.ReleaseLock(ctx, instance); lockReleased {
+			return ctrl.Result{}, lockErr
+		}
+
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
 			condition.ErrorReason,

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -111,7 +111,9 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// The job created by the instance was completed. Release the lock
 		// so that other instances can spawn a job.
 		logging.Info("Job completed")
-		r.ReleaseLock(ctx, instance)
+		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
+			return ctrl.Result{}, err
+		}
 	}
 
 	rbacRules := []rbacv1.PolicyRule{
@@ -202,9 +204,10 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// We are about to start job that spawns the pod with tests.
 	// This lock ensures that there is always only one pod running.
-	if !r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel) {
+	lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
+	if !lockAcquired {
 		logging.Info("Can not acquire lock")
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 	logging.Info("Lock acquired")
 

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
@@ -48,6 +49,11 @@ type TobikoReconciler struct {
 	Reconciler
 }
 
+// GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
+func (r *TobikoReconciler) GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("Controllers").WithName("Tobiko")
+}
+
 //+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/finalizers,verbs=update;patch
@@ -59,11 +65,11 @@ type TobikoReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	Log := r.GetLogger(ctx)
 
 	// How much time should we wait before calling Reconcile loop when there is a failure
 	requeueAfter := time.Second * 60
 
-	logging := log.FromContext(ctx)
 	instance := &testv1beta1.Tobiko{}
 	err := r.Client.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
@@ -110,7 +116,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if r.CompletedJobExists(ctx, instance, currentWorkflowStep) {
 		// The job created by the instance was completed. Release the lock
 		// so that other instances can spawn a job.
-		logging.Info("Job completed")
+		Log.Info("Job completed")
 		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
 			return ctrl.Result{}, err
 		}
@@ -185,7 +191,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	mountKeys := false
 	if (len(instance.Spec.PublicKey) == 0) || (len(instance.Spec.PrivateKey) == 0) {
-		logging.Info("Both values privateKey and publicKey need to be specified. Keys not mounted.")
+		Log.Info("Both values privateKey and publicKey need to be specified. Keys not mounted.")
 	} else {
 		mountKeys = true
 	}
@@ -206,10 +212,10 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// This lock ensures that there is always only one pod running.
 	lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
 	if !lockAcquired {
-		logging.Info("Can not acquire lock")
+		Log.Info("Can not acquire lock")
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
-	logging.Info("Lock acquired")
+	Log.Info("Lock acquired")
 
 	if workflowActive {
 		r.WorkflowStepCounterIncrease(ctx, instance, helper)
@@ -284,7 +290,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	// NetworkAttachments - end
 
-	r.Log.Info("Reconciled Service successfully")
+	Log.Info("Reconciled Service successfully")
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Previously, the logic for releasing test operator lock was written in such a way that it allowed Tempest reconcile loop to delete lock acquired by Tobiko reconcile loop.

This patch fixes this issue by introducing owner field for the test operator lock. The releaceLock function now checks whether the reconcile loop that is trying to delete the lock owns it before proceeding with deletion.