### PR TITLE
Remove dataplane-operator references

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -87,8 +87,6 @@
         override-checkout: main
       - name: github.com/openstack-k8s-operators/repo-setup
         override-checkout: main
-      - name: github.com/openstack-k8s-operators/dataplane-operator
-        override-checkout: main
       - name: github.com/openstack-k8s-operators/infra-operator
         override-checkout: main
       - name: github.com/openstack-k8s-operators/openstack-baremetal-operator


### PR DESCRIPTION
The dataplane-operator is no longer
used as a standalone repo inclusion.