### PR TITLE
Add imageCreationTimeout parameter to Tempest CRD

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -64,6 +64,7 @@
       cifmw_test_operator_tempest_extra_images:
         - URL: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
           name: cirros-0.6.2-test-operator
+          imageCreationTimeout: 300
           flavor:
             name: cirros-0.6.2-test-operator-flavor
             RAM: 512

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -240,6 +240,12 @@ spec:
                           - name
                           - vcpus
                           type: object
+                        imageCreationTimeout:
+                          default: 300
+                          description: Timeout duration for an image to reach the
+                            active state after its creation
+                          format: int64
+                          type: integer
                         name:
                           description: Name of the image
                           type: string
@@ -632,6 +638,12 @@ spec:
                                 - name
                                 - vcpus
                                 type: object
+                              imageCreationTimeout:
+                                default: 300
+                                description: Timeout duration for an image to reach
+                                  the active state after its creation
+                                format: int64
+                                type: integer
                               name:
                                 description: Name of the image
                                 type: string

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -79,6 +79,12 @@ type ExtraImagesType struct {
 	ID string `json:"ID"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:default=300
+	// Timeout duration for an image to reach the active state after its creation
+	ImageCreationTimeout int64 `json:"imageCreationTimeout"`
+
+	// +kubebuilder:validation:Optional
 	// Information about flavor that should be created together with the image
 	Flavor ExtraImagesFlavorType `json:"flavor"`
 }

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -240,6 +240,12 @@ spec:
                           - name
                           - vcpus
                           type: object
+                        imageCreationTimeout:
+                          default: 300
+                          description: Timeout duration for an image to reach the
+                            active state after its creation
+                          format: int64
+                          type: integer
                         name:
                           description: Name of the image
                           type: string
@@ -632,6 +638,12 @@ spec:
                                 - name
                                 - vcpus
                                 type: object
+                              imageCreationTimeout:
+                                default: 300
+                                description: Timeout duration for an image to reach
+                                  the active state after its creation
+                                format: int64
+                                type: integer
                               name:
                                 description: Name of the image
                                 type: string

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -217,6 +217,10 @@ spec:
       - description: How many vcpus should be be allocated when this flavor is used
         displayName: Vcpus
         path: tempestRun.extraImages[0].flavor.vcpus
+      - description: Timeout duration for an image to reach the active state after
+          its creation
+        displayName: Image Creation Timeout
+        path: tempestRun.extraImages[0].imageCreationTimeout
       - description: Cloud that should be used for authentication
         displayName: Os Cloud
         path: tempestRun.extraImages[0].osCloud
@@ -454,6 +458,10 @@ spec:
       - description: How many vcpus should be be allocated when this flavor is used
         displayName: Vcpus
         path: workflow[0].tempestRun.extraImagesType.flavor.vcpus
+      - description: Timeout duration for an image to reach the active state after
+          its creation
+        displayName: Image Creation Timeout
+        path: workflow[0].tempestRun.extraImagesType.imageCreationTimeout
       - description: Cloud that should be used for authentication
         displayName: Os Cloud
         path: workflow[0].tempestRun.extraImagesType.osCloud
@@ -594,9 +602,6 @@ spec:
       - description: Container image for tobiko
         displayName: Container Image
         path: containerImage
-      - description: Run tests in parallel
-        displayName: Debug
-        path: debug
       - description: Name of a secret that contains a kubeconfig. The kubeconfig is
           mounted under /var/lib/tobiko/.kube/config in the test pod.
         displayName: Kubeconfig Secret Name
@@ -615,7 +620,9 @@ spec:
           0 results in automatic decission
         displayName: Num Processes
         path: numProcesses
-      - description: Container image for tobiko
+      - description: By default test-operator executes the test-pods sequentially
+          if multiple instances of test-operator related CRs exist. To run test-pods
+          in parallel set this option to true.
         displayName: Parallel
         path: parallel
       - description: Boolean specifying whether tobiko tests create new resources
@@ -662,9 +669,6 @@ spec:
       - description: Container image for tobiko
         displayName: Container Image
         path: workflow[0].containerImage
-      - description: Run tests in parallel
-        displayName: Debug
-        path: workflow[0].debug
       - description: Name of a secret that contains a kubeconfig. The kubeconfig is
           mounted under /var/lib/tobiko/.kube/config in the test pod.
         displayName: Kubeconfig Secret Name

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -492,6 +492,7 @@ func (r *TempestReconciler) setTempestConfigVars(envVars map[string]string,
 		envVars["TEMPEST_EXTRA_IMAGES_ID"] += extraImageDict.ID + ","
 		envVars["TEMPEST_EXTRA_IMAGES_NAME"] += extraImageDict.Name + ","
 		envVars["TEMPEST_EXTRA_IMAGES_DISK_FORMAT"] += extraImageDict.DiskFormat + ","
+		envVars["TEMPEST_EXTRA_IMAGES_CREATE_TIMEOUT"] += r.GetDefaultInt(extraImageDict.ImageCreationTimeout) + ","
 
 		envVars["TEMPEST_EXTRA_IMAGES_FLAVOR_ID"] += extraImageDict.Flavor.ID + ","
 		envVars["TEMPEST_EXTRA_IMAGES_FLAVOR_NAME"] += extraImageDict.Flavor.Name + ","


### PR DESCRIPTION
This update introduces the imageCreationTimeout parameter to the Tempest CRD. The imageCreationTimeout option allows users to define the maximum duration for an image to transition to the active state after its creation, providing greater control over resource management.