### PR TITLE
Fix test-operator being stuck on NetworkAttachments error

### DIFF
--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -304,7 +304,7 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	if networkReady {
 		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
-	} else {
+	} else if r.JobExists(ctx, instance, externalWorkflowCounter) {
 		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.NetworkAttachmentsReadyCondition,

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -243,7 +243,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	if networkReady {
 		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
-	} else {
+	} else if r.JobExists(ctx, instance, externalWorkflowCounter) {
 		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.NetworkAttachmentsReadyCondition,


### PR DESCRIPTION
This PR [1] introduced a bug that causes test-operator to be stuck on validation of the netowrkAttachments. This is caused by moving the code before the section that is responsible for the job creation. Basically, we are validating whether networkAttachments are correctly configured when there is no test pod to be checked.

This PR ensures that we are raising an error only when a job was created and the networkAttachments are not working.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/135