### PR TITLE
Enable RuntimeDefault SeccompProfile 

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,8 +66,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/pkg/ansibletest/job.go
+++ b/pkg/ansibletest/job.go
@@ -60,6 +60,9 @@ func Job(
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW", "CAP_AUDIT_WRITE"},
 								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 						},
 					},

--- a/pkg/horizontest/job.go
+++ b/pkg/horizontest/job.go
@@ -60,6 +60,9 @@ func Job(
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW", "CAP_AUDIT_WRITE"},
 								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 						},
 					},

--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -64,6 +64,9 @@ func Job(
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{"CAP_AUDIT_WRITE"},
 								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 							EnvFrom: []corev1.EnvFromSource{
 								{

--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -66,6 +66,9 @@ func Job(
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW", "CAP_AUDIT_WRITE"},
 								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
It's a good practice to run containers with RuntimeDefault SeccomProfile that allows only such a system calls that can be expected to be used during normal operation of the container.