### PR TITLE
[Horizontest] Add workflowStep label

### DIFF
--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -110,6 +110,11 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		common.AppSelector: horizontest.ServiceName,
 		"instanceName":     instance.Name,
 		"operator":         "test-operator",
+
+		// NOTE(lpiwowar):  This is a workaround since the Horizontest CR does not support
+		//                  workflows. However, the label might be required by automation that
+		//                  consumes the test-operator (e.g., ci-framework).
+		"workflowStep":     "0",
 	}
 
 	result, err := r.EnsureHorizonTestCloudsYAML(ctx, instance, helper, serviceLabels)


### PR DESCRIPTION
The test-operator role requires jobs spawned by the test-operator to have a workflowStep label [1]. Since the Horizontest CR does not support workflows, there is no way for the test-operator role to gather information about the job spawned by the test-operator.

This patch is a compromise that hardcodes the workflowStep label and always sets it to 0.

[1] https://github.com/openstack-k8s-operators/ci-framework/blob/818cb16a1e008b54af516780eeba43ce2015f438/roles/test_operator/tasks/run-test-operator-job.yml#L48

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2168