### PR TITLE
[18.0.0-proposed] Fix test-operator being stuck on NetworkAttachments error

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -257,10 +257,12 @@ func (r *Reconciler) AcquireLock(
 		return err == nil, err
 	}
 
-	return false, nil
+	return false, err
 }
 
 func (r *Reconciler) ReleaseLock(ctx context.Context, instance client.Object) (bool, error) {
+	Log := r.GetLogger()
+
 	cm, err := r.GetLockInfo(ctx, instance)
 	if err != nil && k8s_errors.IsNotFound(err) {
 		return false, nil
@@ -278,7 +280,20 @@ func (r *Reconciler) ReleaseLock(ctx context.Context, instance client.Object) (b
 		return false, nil
 	}
 
-	return err == nil, err
+	// Check whether the lock was successfully deleted deleted
+	maxRetries := 10
+	lockDeletionSleepPeriod := 10
+	for i := 0; i < maxRetries; i++ {
+		_, err = r.GetLockInfo(ctx, instance)
+		if err != nil && k8s_errors.IsNotFound(err) {
+			return true, nil
+		}
+
+		time.Sleep(time.Second * time.Duration(lockDeletionSleepPeriod))
+		Log.Info("Waiting for the test-operator-lock deletion!")
+	}
+
+	return false, errors.New("failed to delete test-operator-lock")
 }
 
 func (r *Reconciler) WorkflowStepCounterCreate(ctx context.Context, instance client.Object, h *helper.Helper) bool {
@@ -354,13 +369,11 @@ func (r *Reconciler) CompletedJobExists(ctx context.Context, instance client.Obj
 
 func (r *Reconciler) JobExists(ctx context.Context, instance client.Object, workflowStepNum int) bool {
 	job := &batchv1.Job{}
-	err := r.Client.Get(ctx, client.ObjectKey{Namespace: instance.GetNamespace(), Name: r.GetJobName(instance, workflowStepNum)}, job)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			return false
-		} else {
-			return false
-		}
+	jobName := r.GetJobName(instance, workflowStepNum)
+	objectKey := client.ObjectKey{Namespace: instance.GetNamespace(), Name: jobName}
+	err := r.Client.Get(ctx, objectKey, job)
+	if err != nil && k8s_errors.IsNotFound(err) {
+		return false
 	}
 
 	return true

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -270,6 +270,29 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, fmt.Errorf("failed create network annotation from %s: %w",
 			instance.Spec.NetworkAttachments, err)
 	}
+
+	// NetworkAttachments
+	networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, instance.Spec.NetworkAttachments, serviceLabels, 1)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	instance.Status.NetworkAttachments = networkAttachmentStatus
+
+	if networkReady {
+		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
+	} else if r.JobExists(ctx, instance, externalWorkflowCounter) {
+		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.NetworkAttachmentsReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.NetworkAttachmentsReadyErrorMessage,
+			err.Error()))
+
+		return ctrl.Result{}, err
+	}
+	// NetworkAttachments - end
+
 	// Create a new job
 	mountCerts := r.CheckSecretExists(ctx, instance, "combined-ca-bundle")
 	customDataConfigMapName := GetCustomDataConfigMapName(instance, externalWorkflowCounter)
@@ -333,27 +356,6 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrlResult, nil
 	}
 	// Create a new job - end
-	// NetworkAttachments
-	networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, instance.Spec.NetworkAttachments, serviceLabels, 1)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	instance.Status.NetworkAttachments = networkAttachmentStatus
-
-	if networkReady {
-		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
-	} else {
-		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.NetworkAttachmentsReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.NetworkAttachmentsReadyErrorMessage,
-			err.Error()))
-
-		return ctrl.Result{}, err
-	}
-	// NetworkAttachments - end
 
 	Log.Info("Reconciled Service successfully")
 	return ctrl.Result{}, nil


### PR DESCRIPTION
This PR [1] introduced a bug that causes test-operator to be stuck on validation of the netowrkAttachments. This is caused by moving the code before the section that is responsible for the job creation. Basically, we are validating whether networkAttachments are correctly configured when there is no test pod to be checked.

This PR ensures that we are raising an error only when a job was created and the networkAttachments are not working.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/135

This is a cherry-pick of https://github.com/openstack-k8s-operators/test-operator/pull/170