### PR TITLE
Fix JobExists condition for NetworkAttachments 

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -37,6 +37,10 @@
       cifmw_test_operator_tempest_include_list: |
         ^tempest.
       cifmw_test_operator_tempest_exclude_list: |
+        # Note (lpiwowar): Unskip test_verify_hostname_allows_fqdn once the
+        #                  Details: Timeout while verifying metadata on server
+        #                  error is resolved.
+        tempest.api.compute.servers.test_create_server.ServersV294TestFqdnHostnames.test_verify_hostname_allows_fqdn
         tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_migration_with_trunk
         tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
         tempest.api.compute.servers.test_server_rescue.ServerStableDeviceRescueTestIDE

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -296,24 +296,35 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}
 
 	// NetworkAttachments
-	networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, instance.Spec.NetworkAttachments, serviceLabels, 1)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	instance.Status.NetworkAttachments = networkAttachmentStatus
+	if r.JobExists(ctx, instance, externalWorkflowCounter) {
+		networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(
+			ctx,
+			helper,
+			instance.Spec.NetworkAttachments,
+			serviceLabels,
+			1,
+		)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-	if networkReady {
-		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
-	} else if r.JobExists(ctx, instance, externalWorkflowCounter) {
-		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.NetworkAttachmentsReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.NetworkAttachmentsReadyErrorMessage,
-			err.Error()))
+		instance.Status.NetworkAttachments = networkAttachmentStatus
 
-		return ctrl.Result{}, err
+		if networkReady {
+			instance.Status.Conditions.MarkTrue(
+				condition.NetworkAttachmentsReadyCondition,
+				condition.NetworkAttachmentsReadyMessage)
+		} else {
+			err := fmt.Errorf(ErrNetworkAttachments, instance.Spec.NetworkAttachments)
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.NetworkAttachmentsReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.NetworkAttachmentsReadyErrorMessage,
+				err.Error()))
+
+			return ctrl.Result{}, err
+		}
 	}
 	// NetworkAttachments - end
 


### PR DESCRIPTION
This patch moves the JobExists condition to ensure that we are dealing
with NetworkAttachments only after there is an actual Job running.

Also, this patch updates the GetJobName function so that it deals with
situation when we are requesting JobName for non-existing workflow
step.

Also, we have to skip verify_metadata_from_api  for now as this is a new 
test and there seem to be some issues with it unrelated to the test-operator.
(the test is capable of connecting to the VM)