### PR TITLE
Override dhcp_domain flag for FQDN test

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -52,6 +52,7 @@
         tempest.api.identity.admin.v3.test_users.UsersV3TestJSON.test_update_user_password
       cifmw_tempest_tempestconf_config:
         overrides: |
+          compute-feature-enabled.dhcp_domain ''
           identity.v3_endpoint_type public
           service_available.swift false
           service_available.cinder false


### PR DESCRIPTION
test_verify_hostname_allows_fqdn test is failing downstream . This patch overrides dhcp_domain to '' as hostname in metadata doesn't have any suffix for it downstream
