### PR TITLE
Add debug mode for Horizontest

### DIFF
--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -70,6 +70,14 @@ spec:
               dashboardUrl:
                 description: DashboardUrl is the URL of the Horizon dashboard.
                 type: string
+              debug:
+                default: false
+                description: Activate debug mode. When debug mode is activated any
+                  error encountered inside the test-pod causes that the pod will be
+                  kept alive indefinitely (stuck in "Running" phase) or until the
+                  corresponding HorizonTest CR is deleted. This allows the user to
+                  debug any potential troubles with `oc rsh`.
+                type: boolean
               extraConfigmapsMounts:
                 description: Extra configmaps for mounting inside the pod
                 items:

--- a/api/v1beta1/horizontest_types.go
+++ b/api/v1beta1/horizontest_types.go
@@ -28,6 +28,14 @@ import (
 type HorizonTestSpec struct {
 	CommonOptions `json:",inline"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// Activate debug mode. When debug mode is activated any error encountered
+	// inside the test-pod causes that the pod will be kept alive indefinitely
+	// (stuck in "Running" phase) or until the corresponding HorizonTest CR is deleted.
+	// This allows the user to debug any potential troubles with `oc rsh`.
+	Debug bool `json:"debug"`
+
 	// AdminUsername is the username for the OpenStack admin user.
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -70,6 +70,14 @@ spec:
               dashboardUrl:
                 description: DashboardUrl is the URL of the Horizon dashboard.
                 type: string
+              debug:
+                default: false
+                description: Activate debug mode. When debug mode is activated any
+                  error encountered inside the test-pod causes that the pod will be
+                  kept alive indefinitely (stuck in "Running" phase) or until the
+                  corresponding HorizonTest CR is deleted. This allows the user to
+                  debug any potential troubles with `oc rsh`.
+                type: boolean
               extraConfigmapsMounts:
                 description: Extra configmaps for mounting inside the pod
                 items:

--- a/config/samples/test_v1beta1_horizontest.yaml
+++ b/config/samples/test_v1beta1_horizontest.yaml
@@ -10,6 +10,7 @@ metadata:
   name: horizontest-sample
 spec:
   containerImage: ""
+  # debug: false
 
   # OpenStack admin credentials
   adminUsername: "admin"

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -352,6 +352,7 @@ func (r *HorizonTestReconciler) PrepareHorizonTestEnvVars(
 	envVars["PASSWORD"] = env.SetValue("horizontest")
 	envVars["FLAVOR_NAME"] = env.SetValue("m1.tiny")
 	envVars["HORIZON_KEYS_FOLDER"] = env.SetValue("/etc/test_operator")
+	envVars["HORIZONTEST_DEBUG_MODE"] = env.SetValue(r.GetDefaultBool(instance.Spec.Debug))
 
 	return envVars
 }


### PR DESCRIPTION
This patch introduces new option for test-operator that keeps the pod running after a successful run or even after a failure has occurred. It resolves the issue that oc rsh session is killed once the execution of the run_horizontest.sh file finishes.