### PR TITLE
Limit resources

### DIFF
--- a/pkg/ansibletest/job.go
+++ b/pkg/ansibletest/job.go
@@ -62,6 +62,9 @@ func Job(
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    GetVolumeMounts(mountCerts, instance, externalWorkflowCounter),
 							SecurityContext: &securityContext,
+							Resources: corev1.ResourceRequirements{
+								Limits: util.GetResourceLimits(),
+							},
 						},
 					},
 					Volumes: GetVolumes(

--- a/pkg/horizontest/job.go
+++ b/pkg/horizontest/job.go
@@ -61,6 +61,9 @@ func Job(
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    GetVolumeMounts(mountCerts, mountKeys, mountKubeconfig),
 							SecurityContext: &securityContext,
+							Resources: corev1.ResourceRequirements{
+								Limits: util.GetResourceLimits(),
+							},
 						},
 					},
 					Volumes: GetVolumes(

--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -79,6 +79,9 @@ func Job(
 									},
 								},
 							},
+							Resources: corev1.ResourceRequirements{
+								Limits: util.GetResourceLimits(),
+							},
 						},
 					},
 					Volumes: GetVolumes(

--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -68,6 +68,9 @@ func Job(
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    GetVolumeMounts(mountCerts, mountKeys, mountKubeconfig),
 							SecurityContext: &securityContext,
+							Resources: corev1.ResourceRequirements{
+								Limits: util.GetResourceLimits(),
+							},
 						},
 					},
 					Volumes: GetVolumes(

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func GetSecurityContext(
@@ -36,4 +37,11 @@ func GetSecurityContext(
 	}
 
 	return securityContext
+}
+
+func GetResourceLimits() corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("2000m"),
+		corev1.ResourceMemory: resource.MustParse("4Gi"),
+	}
 }


### PR DESCRIPTION
This patch makes sure that there is a resource limit for each pod spawned by the test-operator. The limit is set high enough to ensure proper functioning of the test-operator but low enough to prevent resource draining in the ocp cluster:

- CPU limit: 2000m
- Memory limit: 4Gi