### PR TITLE
Use the most restrictive service account possible

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -43,6 +43,11 @@ spec:
           spec:
             description: AnsibleTestSpec defines the desired state of AnsibleTest
             properties:
+              SELinuxLevel:
+                default: ""
+                description: A SELinuxLevel that should be used for test pods spawned
+                  by the test operator.
+                type: string
               ansibleCollections:
                 default: ""
                 description: AnsibleCollections - extra ansible collections to instal
@@ -191,6 +196,10 @@ spec:
                 description: A parameter that contains a workflow definition.
                 items:
                   properties:
+                    SELinuxLevel:
+                      description: A SELinuxLevel that should be used for test pods
+                        spawned by the test operator.
+                      type: string
                     ansibleCollections:
                       description: AnsibleCollections - extra ansible collections
                         to instal in additionn to the ones exist in the requirements.yaml

--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -43,6 +43,11 @@ spec:
           spec:
             description: HorizonTestSpec defines the desired state of HorizonTest
             properties:
+              SELinuxLevel:
+                default: ""
+                description: A SELinuxLevel that should be used for test pods spawned
+                  by the test operator.
+                type: string
               adminPassword:
                 default: admin
                 description: AdminPassword is the password for the OpenStack admin

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -46,9 +46,9 @@ spec:
               see TempestconfRunSpec.
             properties:
               SELinuxLevel:
-                default: s0:c478,c978
-                description: A SELinuxLevel that is used for all the tempest test
-                  pods.
+                default: ""
+                description: A SELinuxLevel that should be used for test pods spawned
+                  by the test operator.
                 type: string
               SSHKeySecretName:
                 default: ""
@@ -490,6 +490,10 @@ spec:
                     For specific configuration of tempest see TempestRunSpec and for
                     discover-tempest-config see TempestconfRunSpec.
                   properties:
+                    SELinuxLevel:
+                      description: A SELinuxLevel that should be used for test pods
+                        spawned by the test operator.
+                      type: string
                     SSHKeySecretName:
                       description: SSHKeySecretName is the name of the k8s secret
                         that contains an ssh key. The key is mounted to ~/.ssh/id_ecdsa

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -43,6 +43,11 @@ spec:
           spec:
             description: TobikoSpec defines the desired state of Tobiko
             properties:
+              SELinuxLevel:
+                default: ""
+                description: A SELinuxLevel that should be used for test pods spawned
+                  by the test operator.
+                type: string
               backoffLimit:
                 default: 0
                 description: BackoffLimit allows to define the maximum number of retried
@@ -202,6 +207,10 @@ spec:
                 description: A parameter  that contains a workflow definition.
                 items:
                   properties:
+                    SELinuxLevel:
+                      description: A SELinuxLevel that should be used for test pods
+                        spawned by the test operator.
+                      type: string
                     backoffLimit:
                       default: 0
                       description: BackoffLimit allows to define the maximum number

--- a/api/v1beta1/ansibletest_webhook.go
+++ b/api/v1beta1/ansibletest_webhook.go
@@ -67,6 +67,10 @@ func (r *AnsibleTest) ValidateCreate() (admission.Warnings, error) {
 		allWarnings = append(allWarnings, fmt.Sprintf(WarnPrivilegedModeOn, "AnsibleTest"))
 	}
 
+	if r.Spec.Privileged && len(r.Spec.Workflow) > 0 && len(r.Spec.SELinuxLevel) == 0 {
+		allWarnings = append(allWarnings, fmt.Sprintf(WarnSELinuxLevel, r.Kind))
+	}
+
 	return allWarnings, nil
 }
 

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -62,6 +62,14 @@ type CommonOptions struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=""
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// A SELinuxLevel that should be used for test pods spawned by the test
+	// operator.
+	SELinuxLevel string `json:"SELinuxLevel"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=""
 	// A URL of a container image that should be used by the test-operator for tests execution.
 	ContainerImage string `json:"containerImage"`
 
@@ -135,6 +143,13 @@ type WorkflowCommonParameters struct {
 	// +kubebuilder:default:="local-storage"
 	// StorageClass used to create any test-operator related PVCs.
 	StorageClass *string `json:"storageClass"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:Optional
+	// +optional
+	// A SELinuxLevel that should be used for test pods spawned by the test
+	// operator.
+	SELinuxLevel *string `json:"SELinuxLevel,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/common_webhook.go
+++ b/api/v1beta1/common_webhook.go
@@ -21,4 +21,10 @@ const (
 		"set of tests might fail, as this configuration may be " +
 		"required for the tests to run successfully. Before enabling" +
 		"this parameter, consult documentation of the %[1]s CR."
+
+	// WarnSELinuxLevel
+	WarnSELinuxLevel = "%[1]s.Spec.Workflow is used and %[1]s.Spec.Privileged is " +
+		"set to true. Please, consider setting %[1]s.Spec.SELinuxLevel. This " +
+		"ensures that the copying of the logs to the PV is completed without any " +
+		"complications."
 )

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -368,14 +368,8 @@ type TempestconfRunSpec struct {
 // TempestSpec - configuration of execution of tempest. For specific configuration
 // of tempest see TempestRunSpec and for discover-tempest-config see TempestconfRunSpec.
 type TempestSpec struct {
-	CommonOptions              `json:",inline"`
-	CommonOpenstackConfig      `json:",inline"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="s0:c478,c978"
-	// A SELinuxLevel that is used for all the tempest test pods.
-	SELinuxLevel string `json:"SELinuxLevel"`
+	CommonOptions         `json:",inline"`
+	CommonOpenstackConfig `json:",inline"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1beta1/tempest_webhook.go
+++ b/api/v1beta1/tempest_webhook.go
@@ -112,6 +112,10 @@ func (r *Tempest) ValidateCreate() (admission.Warnings, error) {
 		allWarnings = append(allWarnings, fmt.Sprintf(WarnPrivilegedModeOn, "Tempest"))
 	}
 
+	if r.Spec.Privileged && len(r.Spec.Workflow) > 0 && len(r.Spec.SELinuxLevel) == 0 {
+		allWarnings = append(allWarnings, fmt.Sprintf(WarnSELinuxLevel, r.Kind))
+	}
+
 	if len(allErrs) > 0 {
 		return allWarnings, apierrors.NewInvalid(
 			schema.GroupKind{

--- a/api/v1beta1/tobiko_webhook.go
+++ b/api/v1beta1/tobiko_webhook.go
@@ -89,6 +89,10 @@ func (r *Tobiko) ValidateCreate() (admission.Warnings, error) {
 			}, r.GetName(), allErrs)
 	}
 
+	if r.Spec.Privileged && len(r.Spec.Workflow) > 0 && len(r.Spec.SELinuxLevel) == 0 {
+		allWarnings = append(allWarnings, fmt.Sprintf(WarnSELinuxLevel, r.Kind))
+	}
+
 	return allWarnings, nil
 }
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -649,6 +649,11 @@ func (in *WorkflowCommonParameters) DeepCopyInto(out *WorkflowCommonParameters) 
 		*out = new(string)
 		**out = **in
 	}
+	if in.SELinuxLevel != nil {
+		in, out := &in.SELinuxLevel, &out.SELinuxLevel
+		*out = new(string)
+		**out = **in
+	}
 	if in.BackoffLimit != nil {
 		in, out := &in.BackoffLimit, &out.BackoffLimit
 		*out = new(int32)

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -43,6 +43,11 @@ spec:
           spec:
             description: AnsibleTestSpec defines the desired state of AnsibleTest
             properties:
+              SELinuxLevel:
+                default: ""
+                description: A SELinuxLevel that should be used for test pods spawned
+                  by the test operator.
+                type: string
               ansibleCollections:
                 default: ""
                 description: AnsibleCollections - extra ansible collections to instal
@@ -191,6 +196,10 @@ spec:
                 description: A parameter that contains a workflow definition.
                 items:
                   properties:
+                    SELinuxLevel:
+                      description: A SELinuxLevel that should be used for test pods
+                        spawned by the test operator.
+                      type: string
                     ansibleCollections:
                       description: AnsibleCollections - extra ansible collections
                         to instal in additionn to the ones exist in the requirements.yaml

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -43,6 +43,11 @@ spec:
           spec:
             description: HorizonTestSpec defines the desired state of HorizonTest
             properties:
+              SELinuxLevel:
+                default: ""
+                description: A SELinuxLevel that should be used for test pods spawned
+                  by the test operator.
+                type: string
               adminPassword:
                 default: admin
                 description: AdminPassword is the password for the OpenStack admin

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -46,9 +46,9 @@ spec:
               see TempestconfRunSpec.
             properties:
               SELinuxLevel:
-                default: s0:c478,c978
-                description: A SELinuxLevel that is used for all the tempest test
-                  pods.
+                default: ""
+                description: A SELinuxLevel that should be used for test pods spawned
+                  by the test operator.
                 type: string
               SSHKeySecretName:
                 default: ""
@@ -490,6 +490,10 @@ spec:
                     For specific configuration of tempest see TempestRunSpec and for
                     discover-tempest-config see TempestconfRunSpec.
                   properties:
+                    SELinuxLevel:
+                      description: A SELinuxLevel that should be used for test pods
+                        spawned by the test operator.
+                      type: string
                     SSHKeySecretName:
                       description: SSHKeySecretName is the name of the k8s secret
                         that contains an ssh key. The key is mounted to ~/.ssh/id_ecdsa

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -43,6 +43,11 @@ spec:
           spec:
             description: TobikoSpec defines the desired state of Tobiko
             properties:
+              SELinuxLevel:
+                default: ""
+                description: A SELinuxLevel that should be used for test pods spawned
+                  by the test operator.
+                type: string
               backoffLimit:
                 default: 0
                 description: BackoffLimit allows to define the maximum number of retried
@@ -202,6 +207,10 @@ spec:
                 description: A parameter  that contains a workflow definition.
                 items:
                   properties:
+                    SELinuxLevel:
+                      description: A SELinuxLevel that should be used for test pods
+                        spawned by the test operator.
+                      type: string
                     backoffLimit:
                       default: 0
                       description: BackoffLimit allows to define the maximum number

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -18,11 +18,14 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: AnsibleTestStatus is the Schema for the AnsibleTestStatus API
-      displayName: Ansible Test
+    - displayName: Ansible Test
       kind: AnsibleTest
       name: ansibletests.test.openstack.org
       specDescriptors:
+      - description: A SELinuxLevel that should be used for test pods spawned by the
+          test operator.
+        displayName: SELinux Level
+        path: SELinuxLevel
       - description: AnsibleCollections - extra ansible collections to instal in additionn
           to the ones exist in the requirements.yaml
         displayName: Ansible Collections
@@ -54,13 +57,14 @@ spec:
           pod
         displayName: Computes SSHKey Secret Name
         path: computeSSHKeySecretName
-      - description: Container image for AnsibleTest
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: containerImage
       - description: Run ansible playbook with -vvvv
         displayName: Debug
         path: debug
-      - description: Extra configmaps for mounting in the pod.
+      - description: Extra configmaps for mounting inside the pod
         displayName: Extra Configmaps Mounts
         path: extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -72,6 +76,10 @@ spec:
       - description: Config map subpath for mounting, defaults to configmap root.
         displayName: Sub Path
         path: extraConfigmapsMounts[0].subPath
+      - description: This value contains a nodeSelector value that is applied to test
+          pods spawned by the test operator.
+        displayName: Node Selector
+        path: nodeSelector
       - description: OpenStackConfigMap is the name of the ConfigMap containing the
           clouds.yaml
         displayName: Open Stack Config Map
@@ -88,14 +96,22 @@ spec:
           in Tempest CR, or certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
+      - description: This value contains a toleration that is applied to pods spawned
+          by the test pods that are spawned by the test-operator.
+        displayName: Tolerations
+        path: tolerations
       - description: A parameter that contains a workflow definition.
         displayName: Workflow
         path: workflow
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A SELinuxLevel that should be used for test pods spawned by the
+          test operator.
+        displayName: SELinux Level
+        path: workflow[0].SELinuxLevel
       - description: AnsibleCollections - extra ansible collections to instal in additionn
           to the ones exist in the requirements.yaml
         displayName: Ansible Collections
@@ -124,29 +140,34 @@ spec:
         path: workflow[0].backoffLimit
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: ComputesSSHKeySecretName is the name of the k8s secret that contains
+      - description: ComputeSSHKeySecretName is the name of the k8s secret that contains
           an ssh key for computes. The key is mounted to ~/.ssh/id_ecdsa in the ansible
           pod
         displayName: Computes SSHKey Secret Name
         path: workflow[0].computeSSHKeySecretName
-      - description: Container image for AnsibleTest
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: workflow[0].containerImage
       - description: Run ansible playbook with -vvvv
         displayName: Debug
         path: workflow[0].debug
-      - description: Extra configmaps for mounting in the pod
+      - description: Extra configmaps for mounting inside the pod
         displayName: Extra Configmaps Mounts
         path: workflow[0].extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
         displayName: Mount Path
-        path: workflow[0].extraConfigmapsMounts[0].mountPath
+        path: workflow[0].extraConfigmapsMounts.mountPath
       - description: The name of an existing config map for mounting.
         displayName: Name
-        path: workflow[0].extraConfigmapsMounts[0].name
+        path: workflow[0].extraConfigmapsMounts.name
       - description: Config map subpath for mounting, defaults to configmap root.
         displayName: Sub Path
-        path: workflow[0].extraConfigmapsMounts[0].subPath
+        path: workflow[0].extraConfigmapsMounts.subPath
+      - description: This value contains a nodeSelector value that is applied to test
+          pods spawned by the test operator.
+        displayName: Node Selector
+        path: workflow[0].nodeSelector
       - description: OpenStackConfigMap is the name of the ConfigMap containing the
           clouds.yaml
         displayName: Open Stack Config Map
@@ -167,9 +188,13 @@ spec:
           to create a logs directory.
         displayName: Step Name
         path: workflow[0].stepName
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: workflow[0].storageClass
+      - description: This value contains a toleration that is applied to pods spawned
+          by the test pods that are spawned by the test-operator.
+        displayName: Tolerations
+        path: workflow[0].tolerations
       - description: WorkloadSSHKeySecretName is the name of the k8s secret that contains
           an ssh key for the ansible workload. The key is mounted to ~/test_keypair.key
           in the ansible pod
@@ -181,11 +206,14 @@ spec:
         displayName: Workload SSHKey Secret Name
         path: workloadSSHKeySecretName
       version: v1beta1
-    - description: HorizonTest is the Schema for the horizontests API
-      displayName: Horizon Test
+    - displayName: Horizon Test
       kind: HorizonTest
       name: horizontests.test.openstack.org
       specDescriptors:
+      - description: A SELinuxLevel that should be used for test pods spawned by the
+          test operator.
+        displayName: SELinux Level
+        path: SELinuxLevel
       - description: AdminPassword is the password for the OpenStack admin user.
         displayName: Admin Password
         path: adminPassword
@@ -201,12 +229,25 @@ spec:
         path: backoffLimit
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Container image for horizontest
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: containerImage
       - description: DashboardUrl is the URL of the Horizon dashboard.
         displayName: Dashboard Url
         path: dashboardUrl
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: extraConfigmapsMounts
+      - description: Path within the container at which the volume should be mounted.
+        displayName: Mount Path
+        path: extraConfigmapsMounts[0].mountPath
+      - description: The name of an existing config map for mounting.
+        displayName: Name
+        path: extraConfigmapsMounts[0].name
+      - description: Config map subpath for mounting, defaults to configmap root.
+        displayName: Sub Path
+        path: extraConfigmapsMounts[0].subPath
       - description: FlavorName is the name of the OpenStack flavor to create for
           Horizon tests.
         displayName: Flavor Name
@@ -231,6 +272,10 @@ spec:
           logs.
         displayName: Logs Directory Name
         path: logsDirectoryName
+      - description: This value contains a nodeSelector value that is applied to test
+          pods spawned by the test operator.
+        displayName: Node Selector
+        path: nodeSelector
       - description: Parallel
         displayName: Parallel
         path: parallel
@@ -252,19 +297,23 @@ spec:
       - description: RepoUrl is the URL of the Horizon repository.
         displayName: Repo Url
         path: repoUrl
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
+      - description: This value contains a toleration that is applied to pods spawned
+          by the test pods that are spawned by the test-operator.
+        displayName: Tolerations
+        path: tolerations
       - description: User is the username under which the Horizon tests will run.
         displayName: User
         path: user
       version: v1beta1
-    - description: Tempest is the Schema for the tempests API
-      displayName: Tempest
+    - displayName: Tempest
       kind: Tempest
       name: tempests.test.openstack.org
       specDescriptors:
-      - description: A SELinuxLevel that is used for all the tempest test pods.
+      - description: A SELinuxLevel that should be used for test pods spawned by the
+          test operator.
         displayName: SELinux Level
         path: SELinuxLevel
       - description: SSHKeySecretName is the name of the k8s secret that contains
@@ -277,13 +326,18 @@ spec:
         path: backoffLimit
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Activate tempest cleanup. When activated, tempest will run tempest
+          cleanup after test execution is complete to delete any resources created
+          by tempest that may have been left out.
+        displayName: Cleanup
+        path: cleanup
       - description: ConfigOverwrite - interface to overwrite default config files
           like e.g. logging.conf But can also be used to add additional files. Those
           get added to the service config dir in /etc/test_operator/<file>
         displayName: Config Overwrite
         path: configOverwrite
-      - description: An URL of a tempest container image that should be used for the
-          execution of tempest tests.
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: containerImage
       - description: Activate debug mode. When debug mode is activated any error encountered
@@ -292,7 +346,7 @@ spec:
           This allows the user to debug any potential troubles with `oc rsh`.
         displayName: Debug
         path: debug
-      - description: Extra configmaps for mounting in the pod.
+      - description: Extra configmaps for mounting inside the pod
         displayName: Extra Configmaps Mounts
         path: extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -333,8 +387,7 @@ spec:
           in Tempest CR, or certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
-      - description: Name of a storage class that is used to create PVCs for logs
-          storage. Required if default storage class does not exist.
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
       - displayName: Tempest Run
@@ -530,6 +583,10 @@ spec:
           CR hierarchy.
         displayName: Workflow
         path: workflow
+      - description: A SELinuxLevel that should be used for test pods spawned by the
+          test operator.
+        displayName: SELinux Level
+        path: workflow[0].SELinuxLevel
       - description: SSHKeySecretName is the name of the k8s secret that contains
           an ssh key. The key is mounted to ~/.ssh/id_ecdsa in the tempest pod
         displayName: SSHKey Secret Name
@@ -545,10 +602,22 @@ spec:
           get added to the service config dir in /etc/test_operator/<file>
         displayName: Config Overwrite
         path: workflow[0].configOverwrite
-      - description: An URL of a tempest container image that should be used for the
-          execution of tempest tests.
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: workflow[0].containerImage
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: workflow[0].extraConfigmapsMounts
+      - description: Path within the container at which the volume should be mounted.
+        displayName: Mount Path
+        path: workflow[0].extraConfigmapsMounts.mountPath
+      - description: The name of an existing config map for mounting.
+        displayName: Name
+        path: workflow[0].extraConfigmapsMounts.name
+      - description: Config map subpath for mounting, defaults to configmap root.
+        displayName: Sub Path
+        path: workflow[0].extraConfigmapsMounts.subPath
       - description: NetworkAttachments is a list of NetworkAttachment resource names
           to expose the services to the given network
         displayName: Network Attachments
@@ -570,12 +639,19 @@ spec:
           turn off this behaviour then set this option to true.
         displayName: Parallel
         path: workflow[0].parallel
+      - description: 'Use with caution! This parameter specifies whether test-operator
+          should spawn test pods with allowedPrivilegedEscalation: true and the default
+          capabilities on top of capabilities that are usually needed by the test
+          pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
+          for certain test-operator functionalities to work properly (e.g.: extraRPMs
+          in Tempest CR, or certain set of tobiko tests).'
+        displayName: Privileged
+        path: workflow[0].privileged
       - description: Name of a workflow step. The step name will be used for example
           to create a logs directory.
         displayName: Step Name
         path: workflow[0].stepName
-      - description: Name of a storage class that is used to create PVCs for logs
-          storage. Required if default storage class does not exist.
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: workflow[0].storageClass
       - displayName: Tempest Run
@@ -764,11 +840,14 @@ spec:
         displayName: Tolerations
         path: workflow[0].tolerations
       version: v1beta1
-    - description: Tobiko is the Schema for the tobikoes API
-      displayName: Tobiko
+    - displayName: Tobiko
       kind: Tobiko
       name: tobikos.test.openstack.org
       specDescriptors:
+      - description: A SELinuxLevel that should be used for test pods spawned by the
+          test operator.
+        displayName: SELinux Level
+        path: SELinuxLevel
       - description: BackoffLimit allows to define the maximum number of retried executions
           (defaults to 0).
         displayName: Backoff Limit
@@ -778,9 +857,22 @@ spec:
       - description: tobiko.conf
         displayName: Config
         path: config
-      - description: Container image for tobiko
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: containerImage
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: extraConfigmapsMounts
+      - description: Path within the container at which the volume should be mounted.
+        displayName: Mount Path
+        path: extraConfigmapsMounts[0].mountPath
+      - description: The name of an existing config map for mounting.
+        displayName: Name
+        path: extraConfigmapsMounts[0].name
+      - description: Config map subpath for mounting, defaults to configmap root.
+        displayName: Sub Path
+        path: extraConfigmapsMounts[0].subPath
       - description: Name of a secret that contains a kubeconfig. The kubeconfig is
           mounted under /var/lib/tobiko/.kube/config in the test pod.
         displayName: Kubeconfig Secret Name
@@ -826,7 +918,7 @@ spec:
           tests
         displayName: Pytest Addopts
         path: pytestAddopts
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
       - description: Test environment
@@ -844,6 +936,10 @@ spec:
         path: workflow
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: A SELinuxLevel that should be used for test pods spawned by the
+          test operator.
+        displayName: SELinux Level
+        path: workflow[0].SELinuxLevel
       - description: BackoffLimit allows to define the maximum number of retried executions
           (defaults to 0).
         displayName: Backoff Limit
@@ -853,9 +949,22 @@ spec:
       - description: tobiko.conf
         displayName: Config
         path: workflow[0].config
-      - description: Container image for tobiko
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: workflow[0].containerImage
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: workflow[0].extraConfigmapsMounts
+      - description: Path within the container at which the volume should be mounted.
+        displayName: Mount Path
+        path: workflow[0].extraConfigmapsMounts.mountPath
+      - description: The name of an existing config map for mounting.
+        displayName: Name
+        path: workflow[0].extraConfigmapsMounts.name
+      - description: Config map subpath for mounting, defaults to configmap root.
+        displayName: Sub Path
+        path: workflow[0].extraConfigmapsMounts.subPath
       - description: Name of a secret that contains a kubeconfig. The kubeconfig is
           mounted under /var/lib/tobiko/.kube/config in the test pod.
         displayName: Kubeconfig Secret Name
@@ -901,7 +1010,7 @@ spec:
         path: workflow[0].stepName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: workflow[0].storageClass
       - description: Test environment

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,9 +8,22 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -27,6 +40,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""
@@ -43,37 +64,6 @@ rules:
   - batch
   resources:
   - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - secrets
   verbs:
   - create
   - delete
@@ -116,6 +106,8 @@ rules:
   - security.openshift.io
   resourceNames:
   - anyuid
+  - nonroot
+  - nonroot-v2
   - privileged
   resources:
   - securitycontextconstraints

--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -236,6 +236,10 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if instance.Spec.Workflow[externalWorkflowCounter].Tolerations != nil {
 			instance.Spec.Tolerations = *instance.Spec.Workflow[externalWorkflowCounter].Tolerations
 		}
+
+		if instance.Spec.Workflow[externalWorkflowCounter].SELinuxLevel != nil {
+			instance.Spec.SELinuxLevel = *instance.Spec.Workflow[externalWorkflowCounter].SELinuxLevel
+		}
 	}
 
 	// Service account, role, binding

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -18,6 +18,7 @@ import (
 	v1beta1 "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -531,4 +532,21 @@ func (r *Reconciler) OverwriteValueWithWorkflow(
 	}
 
 	return nil
+}
+
+func GetCommonRbacRules(privileged bool) []rbacv1.PolicyRule {
+	rbacPolicyRule := rbacv1.PolicyRule{
+		APIGroups:     []string{"security.openshift.io"},
+		ResourceNames: []string{"nonroot", "nonroot-v2"},
+		Resources:     []string{"securitycontextconstraints"},
+		Verbs:         []string{"use"},
+	}
+
+	if privileged {
+		rbacPolicyRule.ResourceNames = append(
+			rbacPolicyRule.ResourceNames,
+			[]string{"anyuid", "privileged"}...)
+	}
+
+	return []rbacv1.PolicyRule{rbacPolicyRule}
 }

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -34,7 +34,6 @@ import (
 	"gopkg.in/yaml.v3"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,11 +50,19 @@ func (r *HorizonTestReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("HorizonTest")
 }
 
-//+kubebuilder:rbac:groups=test.openstack.org,resources=horizontests,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/finalizers,verbs=update;patch
-//+kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
-//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch
+// +kubebuilder:rbac:groups=test.openstack.org,resources=horizontests,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/finalizers,verbs=update;patch
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
+// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 
 // Reconcile - HorizonTest
 func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -137,27 +144,6 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	rbacRules := []rbacv1.PolicyRule{
-		{
-			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid", "privileged"},
-			Resources:     []string{"securitycontextconstraints"},
-			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
-		},
-	}
-
-	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)
-	if err != nil {
-		return rbacResult, err
-	} else if (rbacResult != ctrl.Result{}) {
-		return rbacResult, nil
-	}
-
 	serviceLabels := map[string]string{
 		common.AppSelector: horizontest.ServiceName,
 		"instanceName":     instance.Name,
@@ -223,6 +209,16 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Service account, role, binding
+	rbacRules := GetCommonRbacRules(instance.Spec.Privileged)
+	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)
+	if err != nil {
+		return rbacResult, err
+	} else if (rbacResult != ctrl.Result{}) {
+		return rbacResult, nil
+	}
+	// Service account, role, binding - end
 
 	jobDef := horizontest.Job(
 		instance,

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -327,6 +327,10 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		if instance.Spec.Workflow[externalWorkflowCounter].Tolerations != nil {
 			instance.Spec.Tolerations = *instance.Spec.Workflow[externalWorkflowCounter].Tolerations
 		}
+
+		if instance.Spec.Workflow[externalWorkflowCounter].SELinuxLevel != nil {
+			instance.Spec.SELinuxLevel = *instance.Spec.Workflow[externalWorkflowCounter].SELinuxLevel
+		}
 	}
 
 	jobDef := tempest.Job(

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -36,7 +36,6 @@ import (
 	"github.com/openstack-k8s-operators/test-operator/pkg/tempest"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,20 +55,16 @@ func (r *TempestReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups=test.openstack.org,resources=tempests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/finalizers,verbs=update;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
-
-// service account, role, rolebinding
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
-// service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 
 // Reconcile - Tempest
 func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -191,33 +186,6 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		}
 	}
 
-	// Service account, role, binding
-	rbacRules := []rbacv1.PolicyRule{
-		{
-			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid", "privileged"},
-			Resources:     []string{"securitycontextconstraints"},
-			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"persistentvolumeclaims"},
-			Verbs:     []string{"get", "list", "create", "update", "watch", "patch"},
-		},
-	}
-	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)
-	if err != nil {
-		return rbacResult, err
-	} else if (rbacResult != ctrl.Result{}) {
-		return rbacResult, nil
-	}
-	// Service account, role, binding - end
-
 	serviceLabels := map[string]string{
 		common.AppSelector: tempest.ServiceName,
 		"workflowStep":     strconv.Itoa(externalWorkflowCounter),
@@ -338,6 +306,16 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Service account, role, binding
+	rbacRules := GetCommonRbacRules(instance.Spec.Privileged)
+	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)
+	if err != nil {
+		return rbacResult, err
+	} else if (rbacResult != ctrl.Result{}) {
+		return rbacResult, nil
+	}
+	// Service account, role, binding - end
 
 	// Note(lpiwowar): Remove all the workflow merge code to webhook once it is done.
 	//                 It will simplify the logic and duplicite code (Tempest vs Tobiko)

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -422,6 +422,10 @@ func (r *TobikoReconciler) PrepareTobikoEnvVars(
 		if instance.Spec.Workflow[step].Tolerations != nil {
 			instance.Spec.Tolerations = *instance.Spec.Workflow[step].Tolerations
 		}
+
+		if instance.Spec.Workflow[step].SELinuxLevel != nil {
+			instance.Spec.SELinuxLevel = *instance.Spec.Workflow[step].SELinuxLevel
+		}
 	}
 
 	// Prepare env vars

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -37,7 +37,6 @@ import (
 	"gopkg.in/yaml.v3"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,16 +53,21 @@ func (r *TobikoReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("Tobiko")
 }
 
-//+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/finalizers,verbs=update;patch
-//+kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
-//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch
+// +kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/finalizers,verbs=update;patch
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
+// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
+// Reconcile - Tobiko
 func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
 	Log := r.GetLogger(ctx)
 
@@ -169,27 +173,6 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
 			return ctrl.Result{}, err
 		}
-	}
-
-	rbacRules := []rbacv1.PolicyRule{
-		{
-			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid", "privileged"},
-			Resources:     []string{"securitycontextconstraints"},
-			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
-		},
-	}
-
-	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)
-	if err != nil {
-		return rbacResult, err
-	} else if (rbacResult != ctrl.Result{}) {
-		return rbacResult, nil
 	}
 
 	serviceLabels := map[string]string{
@@ -311,6 +294,16 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Service account, role, binding
+	rbacRules := GetCommonRbacRules(privileged)
+	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)
+	if err != nil {
+		return rbacResult, err
+	} else if (rbacResult != ctrl.Result{}) {
+		return rbacResult, nil
+	}
+	// Service account, role, binding - end
 
 	jobDef := tobiko.Job(
 		instance,

--- a/pkg/ansibletest/job.go
+++ b/pkg/ansibletest/job.go
@@ -78,5 +78,11 @@ func Job(
 		},
 	}
 
+	if len(instance.Spec.SELinuxLevel) > 0 {
+		job.Spec.Template.Spec.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
+			Level: instance.Spec.SELinuxLevel,
+		}
+	}
+
 	return job
 }

--- a/pkg/horizontest/job.go
+++ b/pkg/horizontest/job.go
@@ -76,5 +76,11 @@ func Job(
 		},
 	}
 
+	if len(instance.Spec.SELinuxLevel) > 0 {
+		job.Spec.Template.Spec.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
+			Level: instance.Spec.SELinuxLevel,
+		}
+	}
+
 	return job
 }

--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -49,9 +49,6 @@ func Job(
 						RunAsUser:  &runAsUser,
 						RunAsGroup: &runAsGroup,
 						FSGroup:    &runAsGroup,
-						SELinuxOptions: &corev1.SELinuxOptions{
-							Level: instance.Spec.SELinuxLevel,
-						},
 					},
 					Tolerations:  instance.Spec.Tolerations,
 					NodeSelector: instance.Spec.NodeSelector,
@@ -91,6 +88,12 @@ func Job(
 				},
 			},
 		},
+	}
+
+	if len(instance.Spec.SELinuxLevel) > 0 {
+		job.Spec.Template.Spec.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
+			Level: instance.Spec.SELinuxLevel,
+		}
 	}
 
 	return job

--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -82,5 +82,11 @@ func Job(
 		},
 	}
 
+	if len(instance.Spec.SELinuxLevel) > 0 {
+		job.Spec.Template.Spec.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{
+			Level: instance.Spec.SELinuxLevel,
+		}
+	}
+
 	return job
 }

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -16,9 +16,7 @@ func GetSecurityContext(
 		RunAsUser:                &runAsUser,
 		RunAsGroup:               &runAsUser,
 		AllowPrivilegeEscalation: &falseVar,
-		Capabilities: &corev1.Capabilities{
-			Add: addCapabilities,
-		},
+		Capabilities:             &corev1.Capabilities{},
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
@@ -28,6 +26,7 @@ func GetSecurityContext(
 		// We need to run pods with AllowPrivilegedEscalation: true to remove
 		// nosuid from the pod (in order to be able to run sudo)
 		securityContext.AllowPrivilegeEscalation = &trueVar
+		securityContext.Capabilities.Add = addCapabilities
 	}
 
 	if !privileged {


### PR DESCRIPTION
This PR ensures that the test-operator spawns test pods with the least amount of privileges that are required for successful execution of the tests inside the pods. Three changes had to be made:

1. Triage rules assigned to serviceAccounts

- This patch ensures that serviceAccounts have only such rights that are really needed for the tests execution.

2. Do not add capabilities when `privileged: false`

- Previously we were adding the NET_ADMIN and NET_RAW capabilities even when `privileged: false`. This required to run the test pod with privileged scc. 

3. Remove default value for SELinuxLevel

- Setting the SELinuxLevel on a test pod requires it to run with elevated scc. This patch removes the default value for the SELinuxLevel (secure by default) and leaves the setting up to the user (when `privileged: true` is used).

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2448
