### PR TITLE
Fix mistake in horizon_controller.go

### DIFF
--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -48,7 +48,7 @@ type HorizonTestReconciler struct {
 
 // GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
 func (r *HorizonTestReconciler) GetLogger(ctx context.Context) logr.Logger {
-	return log.FromContext(ctx).WithName("Controllers").WithName("Tobiko")
+	return log.FromContext(ctx).WithName("Controllers").WithName("HorizonTest")
 }
 
 //+kubebuilder:rbac:groups=test.openstack.org,resources=horizontests,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
This commit fixes mistake in GetLogger function in horizon_controller.go as to make it correctly work for horizontest