### PR TITLE
[zuul] Move test-operator job to stages

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -37,76 +37,83 @@
 
       # Tempest
       cifmw_run_tempest: true
-      cifmw_test_operator_tempest_cleanup: true
-      cifmw_test_operator_tempest_include_list: |
-        ^tempest.
-      cifmw_test_operator_tempest_exclude_list: |
-        # Note (lpiwowar): Unskip test_verify_hostname_allows_fqdn once the
-        #                  Details: Timeout while verifying metadata on server
-        #                  error is resolved.
-        tempest.api.compute.servers.test_create_server.ServersV294TestFqdnHostnames.test_verify_hostname_allows_fqdn
-        tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_migration_with_trunk
-        tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
-        tempest.api.compute.servers.test_server_rescue.ServerStableDeviceRescueTestIDE
-        tempest.api.compute.servers.test_device_tagging
-        tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON
-        tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario
-        tempest.scenario.test_stamp_pattern
-        tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
-        tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
-        test_create_server_invalid_bdm_in_2nd_dict
-        tempest.api.identity.admin.v3.test_credentials.CredentialsTestJSON
-        tempest.api.identity.admin.v3.test_tokens.TokensV3TestJSON.test_rescope_token
-        tempest.api.identity.admin.v3.test_users.UsersV3TestJSON.test_update_user_password
-      cifmw_test_operator_tempest_expected_failures_list: |
-        foobar
-      cifmw_tempest_tempestconf_config:
-        overrides: |
-          compute-feature-enabled.dhcp_domain ''
-          identity.v3_endpoint_type public
-          service_available.swift false
-          service_available.cinder false
-      cifmw_test_operator_tempest_workflow:
-        - stepName: 'full'
-        - stepName: 'single-test'
-          tempestRun:
-            includeList: |
-              tempest.api.compute.admin.test_flavors.FlavorsAdminTestJSON.test_create_flavor_using_string_ram
-      cifmw_test_operator_tempest_extra_images:
-        - URL: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
-          name: cirros-0.6.2-test-operator
-          imageCreationTimeout: 300
-          flavor:
-            name: cirros-0.6.2-test-operator-flavor
-            RAM: 512
-            disk: 20
-            vcpus: 1
-      cifmw_test_operator_tempest_ntp_extra_images: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
-      cifmw_test_operator_tempest_network_attachments:
-        - ctlplane
+      cifmw_test_operator_stages:
+        - name: tempest
+          type: tempest
+          test_vars:
+            cifmw_test_operator_tempest_cleanup: true
+            cifmw_test_operator_tempest_expected_failures_list: |
+              foobar
+            cifmw_test_operator_tempest_include_list: |
+              ^tempest.
+            cifmw_test_operator_tempest_exclude_list: |
+              # Note (lpiwowar): Unskip test_verify_hostname_allows_fqdn once the
+              #                  Details: Timeout while verifying metadata on server
+              #                  error is resolved.
+              tempest.api.compute.servers.test_create_server.ServersV294TestFqdnHostnames.test_verify_hostname_allows_fqdn
+              tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_migration_with_trunk
+              tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
+              tempest.api.compute.servers.test_server_rescue.ServerStableDeviceRescueTestIDE
+              tempest.api.compute.servers.test_device_tagging
+              tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON
+              tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario
+              tempest.scenario.test_stamp_pattern
+              tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_live_migration
+              tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
+              test_create_server_invalid_bdm_in_2nd_dict
+              tempest.api.identity.admin.v3.test_credentials.CredentialsTestJSON
+              tempest.api.identity.admin.v3.test_tokens.TokensV3TestJSON.test_rescope_token
+              tempest.api.identity.admin.v3.test_users.UsersV3TestJSON.test_update_user_password
+            cifmw_test_operator_tempest_tempestconf_config:
+              overrides: |
+                compute-feature-enabled.dhcp_domain ''
+                identity.v3_endpoint_type public
+                service_available.swift false
+                service_available.cinder false
+            cifmw_test_operator_tempest_workflow:
+              - stepName: 'full'
+              - stepName: 'single-test'
+                tempestRun:
+                  includeList: |
+                    tempest.api.compute.admin.test_flavors.FlavorsAdminTestJSON.test_create_flavor_using_string_ram
+            cifmw_test_operator_tempest_extra_images:
+              - URL: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
+                name: cirros-0.6.2-test-operator
+                imageCreationTimeout: 300
+                flavor:
+                  name: cirros-0.6.2-test-operator-flavor
+                  RAM: 512
+                  disk: 20
+                  vcpus: 1
+            cifmw_test_operator_tempest_ntp_extra_images: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
+            cifmw_test_operator_tempest_network_attachments:
+              - ctlplane
 
-      # Tobiko
-      cifmw_run_tobiko: true
-      cifmw_test_operator_tobiko_workflow:
-        - stepName: 'podified-functional'
-          testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'
-          numProcesses: 2
-        - stepName: 'sanity'
-          testenv: 'sanity'
-      cifmw_test_operator_tobiko_network_attachments:
-        - ctlplane
+        - name: tobiko
+          type: tobiko
+          test_vars:
+            cifmw_run_tobiko: true
+            cifmw_test_operator_tobiko_workflow:
+              - stepName: 'podified-functional'
+                testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'
+                numProcesses: 2
+              - stepName: 'sanity'
+                testenv: 'sanity'
+            cifmw_test_operator_tobiko_network_attachments:
+              - ctlplane
 
-      # Ansibletest
-      run_ansibletest: true
-      cifmw_test_operator_ansibletest_ansible_git_repo: https://github.com/ansible/test-playbooks
-      cifmw_test_operator_ansibletest_ansible_playbook_path: ./debug.yml
-      cifmw_test_operator_ansibletest_workload_ssh_key_secret_name: test-operator-controller-priv-key
-      cifmw_test_operator_ansibletest_ansible_extra_vars: -e manual_run=false
-      cifmw_test_operator_ansibletest_ansible_inventory: |
-        localhost ansible_connection=local ansible_python_interpreter=python3
-      cifmw_test_operator_ansibletest_ansible_var_files: |
-        ---
-        foo: bar
+        - name: ansibletest
+          type: ansibletest
+          test_vars:
+            cifmw_test_operator_ansibletest_ansible_git_repo: https://github.com/ansible/test-playbooks
+            cifmw_test_operator_ansibletest_ansible_playbook_path: ./debug.yml
+            cifmw_test_operator_ansibletest_workload_ssh_key_secret_name: test-operator-controller-priv-key
+            cifmw_test_operator_ansibletest_ansible_extra_vars: -e manual_run=false
+            cifmw_test_operator_ansibletest_ansible_inventory: |
+              localhost ansible_connection=local ansible_python_interpreter=python3
+            cifmw_test_operator_ansibletest_ansible_var_files: |
+              ---
+              foo: bar
     required-projects: &rp
       - name: openstack-k8s-operators/install_yamls
         override-checkout: main


### PR DESCRIPTION
The linked PR for the test-oprator role introduces the concept of
stages. This patch updates the job definition so that it is
consuming the newly defined interface. It is required because by
default only the tempest stage is enabled.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2374
