### PR TITLE
[zuul] Enable tempest cleanup

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -37,6 +37,7 @@
 
       # Tempest
       cifmw_run_tempest: true
+      cifmw_test_operator_tempest_cleanup: true
       cifmw_test_operator_tempest_include_list: |
         ^tempest.
       cifmw_test_operator_tempest_exclude_list: |


### PR DESCRIPTION
This patch enables the tempest cleanup feature that cleans all
resources created during the tempest test execution.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2381
