### PR TITLE
Unify webhook error messages

### DIFF
--- a/api/v1beta1/common_webhook.go
+++ b/api/v1beta1/common_webhook.go
@@ -4,6 +4,9 @@ const (
 	// ErrPrivilegedModeRequired
 	ErrPrivilegedModeRequired = "%s.Spec.Privileged is requied in order to successfully " +
 		"execute tests with the provided configuration."
+
+	// ErrDebug
+	ErrDebug = "%s.Spec.Workflow parameter must be empty to run debug mode"
 )
 
 const (

--- a/api/v1beta1/tempest_webhook.go
+++ b/api/v1beta1/tempest_webhook.go
@@ -92,7 +92,11 @@ func (r *Tempest) ValidateCreate() (admission.Warnings, error) {
 	var allWarnings admission.Warnings
 
 	if len(r.Spec.Workflow) > 0 && r.Spec.Debug {
-		return nil, errors.New("workflow variable must be empty to run debug mode")
+		allErrs = append(allErrs, &field.Error{
+			Type:     field.ErrorTypeForbidden,
+			BadValue: r.Spec.Workflow,
+			Detail:   fmt.Sprintf(ErrDebug, "Tempest"),
+		})
 	}
 
 	if !r.Spec.Privileged && r.PrivilegedRequired() {


### PR DESCRIPTION
This patch unifies the error messages returned by the test operator
webhooks. Previously, some error messages were returned from the
validateCreate as a plain errors. This made the error messages
unreadable.
    
This patch returns all the errors in field.ErrorList. Each error is
properly categorized with Type and Detail err message.
