### PR TITLE
Increase ResourceMemory limit

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -42,6 +42,6 @@ func GetSecurityContext(
 func GetResourceLimits() corev1.ResourceList {
 	return corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse("2000m"),
-		corev1.ResourceMemory: resource.MustParse("4Gi"),
+		corev1.ResourceMemory: resource.MustParse("8Gi"),
 	}
 }


### PR DESCRIPTION
We are hitting an issue when pods are being killed in jobs because of OOM error. It seems like the ResourceMemory limit set with this PR [1] is not enough for the test operator pods.

This patch increases the ResourceMemory limit to 8Gi. We should revisit this problem later and investigate whether the limit can not be lower and what exactly caused the OOM errors.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/205