### PR TITLE
Remove resource limit

### DIFF
--- a/pkg/ansibletest/job.go
+++ b/pkg/ansibletest/job.go
@@ -64,9 +64,6 @@ func Job(
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    GetVolumeMounts(mountCerts, instance, externalWorkflowCounter),
 							SecurityContext: &securityContext,
-							Resources: corev1.ResourceRequirements{
-								Limits: util.GetResourceLimits(),
-							},
 						},
 					},
 					Volumes: GetVolumes(

--- a/pkg/horizontest/job.go
+++ b/pkg/horizontest/job.go
@@ -63,9 +63,6 @@ func Job(
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    GetVolumeMounts(mountCerts, mountKeys, mountKubeconfig, instance),
 							SecurityContext: &securityContext,
-							Resources: corev1.ResourceRequirements{
-								Limits: util.GetResourceLimits(),
-							},
 						},
 					},
 					Volumes: GetVolumes(

--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -79,9 +79,6 @@ func Job(
 									},
 								},
 							},
-							Resources: corev1.ResourceRequirements{
-								Limits: util.GetResourceLimits(),
-							},
 						},
 					},
 					Volumes: GetVolumes(

--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -68,9 +68,6 @@ func Job(
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    GetVolumeMounts(mountCerts, mountKeys, mountKubeconfig, instance),
 							SecurityContext: &securityContext,
-							Resources: corev1.ResourceRequirements{
-								Limits: util.GetResourceLimits(),
-							},
 						},
 					},
 					Volumes: GetVolumes(

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func GetSecurityContext(
@@ -37,11 +36,4 @@ func GetSecurityContext(
 	}
 
 	return securityContext
-}
-
-func GetResourceLimits() corev1.ResourceList {
-	return corev1.ResourceList{
-		corev1.ResourceCPU:    resource.MustParse("2000m"),
-		corev1.ResourceMemory: resource.MustParse("8Gi"),
-	}
 }


### PR DESCRIPTION
This patch removes the resource limit for test operator pods as we are hitting both issue when:

- the limit is too low
- the limit is too high (scheduler does not have where to schedule the pod)

This is a hotfix before we expose the resource limit values through the test-operator CRs and find the correct default values.

Related PRs:
- https://github.com/openstack-k8s-operators/test-operator/pull/222
- https://github.com/openstack-k8s-operators/test-operator/pull/205