### PR TITLE
Fix lint issues

### DIFF
--- a/api/v1beta1/common_webhook.go
+++ b/api/v1beta1/common_webhook.go
@@ -3,19 +3,19 @@ package v1beta1
 const (
 	// ErrPrivilegedModeRequired
 	ErrPrivilegedModeRequired = "%s.Spec.Privileged is requied in order to successfully " +
-	                            "execute tests with the provided configuration."
+		"execute tests with the provided configuration."
 )
 
 const (
 	// WarnPrivilegedModeOn
 	WarnPrivilegedModeOn = "%s.Spec.Privileged is set to true. This means that test pods " +
-												 "are spawned with allowPrivilegedEscalation: true and default " +
-												 "capabilities on top of those required by the test operator " +
-												 "(NET_ADMIN, NET_RAW)."
+		"are spawned with allowPrivilegedEscalation: true and default " +
+		"capabilities on top of those required by the test operator " +
+		"(NET_ADMIN, NET_RAW)."
 
 	// WarnPrivilegedModeOff
 	WarnPrivilegedModeOff = "%[1]s.Spec.Privileged is set to false. Note, that a certain " +
-	                        "set of tests might fail, as this configuration may be " +
-													"required for the tests to run successfully. Before enabling" +
-													"this parameter, consult documentation of the %[1]s CR."
+		"set of tests might fail, as this configuration may be " +
+		"required for the tests to run successfully. Before enabling" +
+		"this parameter, consult documentation of the %[1]s CR."
 )

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -57,15 +57,7 @@ func (r *HorizonTestReconciler) GetLogger(ctx context.Context) logr.Logger {
 //+kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the HorizonTest object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
+// Reconcile - HorizonTest
 func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
 	Log := r.GetLogger(ctx)
 


### PR DESCRIPTION
This patch addresses two issues:

- incorrect indentation in common_webhook.go
- removal of automatically generated comments
