### PR TITLE
Add test-reviewers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,5 +6,6 @@ approvers:
 
 reviewers:
   - test-approvers
+  - test-reviewers
   - openstack-approvers
   - ci-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,5 +12,8 @@ aliases:
   - stuggi
   test-approvers:
   - lpiwowar
-  - kstrenkova
   - kopecmartin
+  test-reviewers:
+  - kstrenkova
+  - evallesp
+  - frenzyfriday


### PR DESCRIPTION
This patch adds reviewers who would be capable of adding /lgtm on test-operator PRs.