### PR TITLE
[OSPRH-11191] Remove dereference for nil pointer

### DIFF
--- a/pkg/ansibletest/volumes.go
+++ b/pkg/ansibletest/volumes.go
@@ -106,7 +106,7 @@ func GetVolumes(
 		volumes = append(volumes, extraVol)
 	}
 
-	if len(instance.Spec.Workflow) > 0 && *instance.Spec.Workflow[externalWorkflowCounter].ExtraConfigmapsMounts != nil {
+	if len(instance.Spec.Workflow) > 0 && instance.Spec.Workflow[externalWorkflowCounter].ExtraConfigmapsMounts != nil {
 		for _, vol := range *instance.Spec.Workflow[externalWorkflowCounter].ExtraConfigmapsMounts {
 			extraWorkflowVol := corev1.Volume{
 				Name: vol.Name,
@@ -204,7 +204,7 @@ func GetVolumeMounts(mountCerts bool, instance *testv1beta1.AnsibleTest, externa
 		volumeMounts = append(volumeMounts, extraConfigmapsMounts)
 	}
 
-	if len(instance.Spec.Workflow) > 0 && *instance.Spec.Workflow[externalWorkflowCounter].ExtraConfigmapsMounts != nil {
+	if len(instance.Spec.Workflow) > 0 && instance.Spec.Workflow[externalWorkflowCounter].ExtraConfigmapsMounts != nil {
 		for _, vol := range *instance.Spec.Workflow[externalWorkflowCounter].ExtraConfigmapsMounts {
 
 			extraConfigmapsMounts := corev1.VolumeMount{


### PR DESCRIPTION
This patch fixes the issue when ExtraConfigmapsMounts is empty.
Dereferencing a nil pointer leads to a panic.

We now first check whether the pointer is nil and then move to
dereferencing it.
