### PR TITLE
Change suggested namespace to openstack-operators

### DIFF
--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operatorframework.io/suggested-namespace: openstack
+    operatorframework.io/suggested-namespace: openstack-operators
   name: test-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
The test-operator should be running in a namespace separate from its
oeprators (test pods). Ultimatelly this means that the test-operator
should be running in the openstack-oeprators namespace with the other
openstack operators.

This patch changes the suggested namespace value in the Test Operator
CSV from openstack to openstack-operators.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2580
