### PR TITLE
Turn off automatic mounting of service account tokens

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -139,10 +139,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+                  true and the default capabilities on top of capabilities that are
+                  usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -151,10 +151,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+                  true and the default capabilities on top of capabilities that are
+                  usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -142,10 +142,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+                  true and the default capabilities on top of capabilities that are
+                  usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -133,10 +133,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+                  true and the default capabilities on top of capabilities that are
+                  usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -46,11 +46,11 @@ type CommonOptions struct {
 	// +kubebuilder:default=false
 	// +optional
 	// Use with caution! This parameter specifies whether test-operator should spawn test
-	// pods with allowedPrivilegedEscalation: true and the default capabilities on
-	// top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
-	// This parameter is deemed insecure but it is needed for certain test-operator
-	// functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
-	// of tobiko tests).
+	// pods with allowedPrivilegedEscalation: true, automountServiceAccountToken: true
+	// and the default capabilities on top of capabilities that are usually needed
+	// by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+	// but it is needed for certain test-operator functionalities to work properly
+	// (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).
 	Privileged bool `json:"privileged"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -139,10 +139,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+                  true and the default capabilities on top of capabilities that are
+                  usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -151,10 +151,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+                  true and the default capabilities on top of capabilities that are
+                  usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -142,10 +142,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+                  true and the default capabilities on top of capabilities that are
+                  usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -133,10 +133,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+                  true and the default capabilities on top of capabilities that are
+                  usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -89,11 +89,11 @@ spec:
         displayName: Open Stack Config Secret
         path: openStackConfigSecret
       - description: 'Use with caution! This parameter specifies whether test-operator
-          should spawn test pods with allowedPrivilegedEscalation: true and the default
-          capabilities on top of capabilities that are usually needed by the test
-          pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
-          for certain test-operator functionalities to work properly (e.g.: extraRPMs
-          in Tempest CR, or certain set of tobiko tests).'
+          should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+          true and the default capabilities on top of capabilities that are usually
+          needed by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+          but it is needed for certain test-operator functionalities to work properly
+          (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
       - description: StorageClass used to create any test-operator related PVCs.
@@ -283,11 +283,11 @@ spec:
         displayName: Password
         path: password
       - description: 'Use with caution! This parameter specifies whether test-operator
-          should spawn test pods with allowedPrivilegedEscalation: true and the default
-          capabilities on top of capabilities that are usually needed by the test
-          pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
-          for certain test-operator functionalities to work properly (e.g.: extraRPMs
-          in Tempest CR, or certain set of tobiko tests).'
+          should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+          true and the default capabilities on top of capabilities that are usually
+          needed by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+          but it is needed for certain test-operator functionalities to work properly
+          (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
       - description: ProjectName is the name of the OpenStack project for Horizon
@@ -380,11 +380,11 @@ spec:
         displayName: Parallel
         path: parallel
       - description: 'Use with caution! This parameter specifies whether test-operator
-          should spawn test pods with allowedPrivilegedEscalation: true and the default
-          capabilities on top of capabilities that are usually needed by the test
-          pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
-          for certain test-operator functionalities to work properly (e.g.: extraRPMs
-          in Tempest CR, or certain set of tobiko tests).'
+          should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+          true and the default capabilities on top of capabilities that are usually
+          needed by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+          but it is needed for certain test-operator functionalities to work properly
+          (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
       - description: StorageClass used to create any test-operator related PVCs.
@@ -398,6 +398,11 @@ spec:
       - description: A content of exclude.txt file that is passed to tempest via --exclude-list
         displayName: Exclude List
         path: tempestRun.excludeList
+      - description: The expectedFailuresList parameter contains tests that should
+          not count as failures. When a test from this list fails, the test pod ends
+          with Completed state rather than with Error state.
+        displayName: Expected Failures List
+        path: tempestRun.expectedFailuresList
       - description: ExternalPlugin contains information about plugin that should
           be installed within the tempest test pod. If this option is specified then
           only tests that are part of the external plugin can be executed.
@@ -662,6 +667,11 @@ spec:
       - description: A content of exclude.txt file that is passed to tempest via --exclude-list
         displayName: Exclude List
         path: workflow[0].tempestRun.excludeList
+      - description: The expectedFailuresList parameter contains tests that should
+          not count as failures. When a test from this list fails, the test pod ends
+          with Completed state rather than with Error state.
+        displayName: Expected Failures List
+        path: workflow[0].tempestRun.expectedFailuresList
       - description: ExternalPlugin contains information about plugin that should
           be installed within the tempest test pod. If this option is specified then
           only tests that are part of the external plugin can be executed.
@@ -904,11 +914,11 @@ spec:
         displayName: Private Key
         path: privateKey
       - description: 'Use with caution! This parameter specifies whether test-operator
-          should spawn test pods with allowedPrivilegedEscalation: true and the default
-          capabilities on top of capabilities that are usually needed by the test
-          pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
-          for certain test-operator functionalities to work properly (e.g.: extraRPMs
-          in Tempest CR, or certain set of tobiko tests).'
+          should spawn test pods with allowedPrivilegedEscalation: true, automountServiceAccountToken:
+          true and the default capabilities on top of capabilities that are usually
+          needed by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+          but it is needed for certain test-operator functionalities to work properly
+          (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
       - description: Public Key

--- a/pkg/ansibletest/job.go
+++ b/pkg/ansibletest/job.go
@@ -47,8 +47,9 @@ func Job(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: instance.RbacResourceName(),
+					AutomountServiceAccountToken: &instance.Spec.Privileged,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					ServiceAccountName:           instance.RbacResourceName(),
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,
 						RunAsGroup: &runAsGroup,

--- a/pkg/horizontest/job.go
+++ b/pkg/horizontest/job.go
@@ -46,8 +46,9 @@ func Job(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: instance.RbacResourceName(),
+					AutomountServiceAccountToken: &instance.Spec.Privileged,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					ServiceAccountName:           instance.RbacResourceName(),
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,
 						RunAsGroup: &runAsGroup,

--- a/pkg/tempest/job.go
+++ b/pkg/tempest/job.go
@@ -43,8 +43,9 @@ func Job(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: instance.RbacResourceName(),
+					AutomountServiceAccountToken: &instance.Spec.Privileged,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					ServiceAccountName:           instance.RbacResourceName(),
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,
 						RunAsGroup: &runAsGroup,

--- a/pkg/tobiko/job.go
+++ b/pkg/tobiko/job.go
@@ -51,8 +51,9 @@ func Job(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: instance.RbacResourceName(),
+					AutomountServiceAccountToken: &instance.Spec.Privileged,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					ServiceAccountName:           instance.RbacResourceName(),
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser:  &runAsUser,
 						RunAsGroup: &runAsGroup,


### PR DESCRIPTION
This patch turns off automatic mounting of service account tokens. When a test pod has an access to a service account token it can modify the state of the kubernetes cluster (based on to role assigned to the account). Therefore, it is a good practice to keep the token unmounted by default (unless necessary).

This behavior can be overriden by setting `privileged: true`.