### PR TITLE
Set runAsNonRoot: true by default

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -134,10 +134,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+                  false, and the default capabilities on top of capabilities that
+                  are usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -146,10 +146,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+                  false, and the default capabilities on top of capabilities that
+                  are usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -142,10 +142,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+                  false, and the default capabilities on top of capabilities that
+                  are usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -128,10 +128,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+                  false, and the default capabilities on top of capabilities that
+                  are usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -46,11 +46,11 @@ type CommonOptions struct {
 	// +kubebuilder:default=false
 	// +optional
 	// Use with caution! This parameter specifies whether test-operator should spawn test
-	// pods with allowedPrivilegedEscalation: true and the default capabilities on
-	// top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
-	// This parameter is deemed insecure but it is needed for certain test-operator
-	// functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
-	// of tobiko tests).
+	// pods with allowedPrivilegedEscalation: true, runAsNonRoot: false, and the
+	// default capabilities on top of capabilities that are usually needed by the
+	// test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it
+	// is needed for certain test-operator functionalities to work properly (e.g.:
+	// extraRPMs in Tempest CR, or certain set of tobiko tests).
 	Privileged bool `json:"privileged"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -134,10 +134,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+                  false, and the default capabilities on top of capabilities that
+                  are usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -146,10 +146,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+                  false, and the default capabilities on top of capabilities that
+                  are usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -142,10 +142,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+                  false, and the default capabilities on top of capabilities that
+                  are usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -128,10 +128,10 @@ spec:
               privileged:
                 default: false
                 description: 'Use with caution! This parameter specifies whether test-operator
-                  should spawn test pods with allowedPrivilegedEscalation: true and
-                  the default capabilities on top of capabilities that are usually
-                  needed by the test pods (NET_ADMIN, NET_RAW). This parameter is
-                  deemed insecure but it is needed for certain test-operator functionalities
+                  should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+                  false, and the default capabilities on top of capabilities that
+                  are usually needed by the test pods (NET_ADMIN, NET_RAW). This parameter
+                  is deemed insecure but it is needed for certain test-operator functionalities
                   to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                   of tobiko tests).'
                 type: boolean

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -18,8 +18,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: AnsibleTestStatus is the Schema for the AnsibleTestStatus API
-      displayName: Ansible Test
+    - displayName: Ansible Test
       kind: AnsibleTest
       name: ansibletests.test.openstack.org
       specDescriptors:
@@ -43,8 +42,8 @@ spec:
           get added to the
         displayName: Ansible Var Files
         path: ansibleVarFiles
-      - description: BackoffLimimt allows to define the maximum number of retried
-          executions (defaults to 6).
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 0).
         displayName: Backoff Limit
         path: backoffLimit
         x-descriptors:
@@ -54,24 +53,29 @@ spec:
           pod
         displayName: Computes SSHKey Secret Name
         path: computeSSHKeySecretName
-      - description: Container image for AnsibleTest
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: containerImage
       - description: Run ansible playbook with -vvvv
         displayName: Debug
         path: debug
-      - description: Extra configmaps for mounting in the pod.
-        displayName: Extra Mounts
-        path: extraMounts
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
         displayName: Mount Path
-        path: extraMounts[0].mountPath
+        path: extraConfigmapsMounts[0].mountPath
       - description: The name of an existing config map for mounting.
         displayName: Name
-        path: extraMounts[0].name
+        path: extraConfigmapsMounts[0].name
       - description: Config map subpath for mounting, defaults to configmap root.
         displayName: Sub Path
-        path: extraMounts[0].subPath
+        path: extraConfigmapsMounts[0].subPath
+      - description: This value contains a nodeSelector value that is applied to test
+          pods spawned by the test operator.
+        displayName: Node Selector
+        path: nodeSelector
       - description: OpenStackConfigMap is the name of the ConfigMap containing the
           clouds.yaml
         displayName: Open Stack Config Map
@@ -80,10 +84,22 @@ spec:
           secure.yaml
         displayName: Open Stack Config Secret
         path: openStackConfigSecret
-      - description: StorageClass used to create PVCs that store the logs
+      - description: 'Use with caution! This parameter specifies whether test-operator
+          should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+          false, and the default capabilities on top of capabilities that are usually
+          needed by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+          but it is needed for certain test-operator functionalities to work properly
+          (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).'
+        displayName: Privileged
+        path: privileged
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
-      - description: A parameter  that contains a workflow definition.
+      - description: This value contains a toleration that is applied to pods spawned
+          by the test pods that are spawned by the test-operator.
+        displayName: Tolerations
+        path: tolerations
+      - description: A parameter that contains a workflow definition.
         displayName: Workflow
         path: workflow
         x-descriptors:
@@ -110,8 +126,8 @@ spec:
           to the ansible command using -e @/etc/test_operator/<file>
         displayName: Ansible Var Files
         path: workflow[0].ansibleVarFiles
-      - description: BackoffLimimt allows to define the maximum number of retried
-          executions (defaults to 6).
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 0).
         displayName: Backoff Limit
         path: workflow[0].backoffLimit
         x-descriptors:
@@ -121,24 +137,29 @@ spec:
           pod
         displayName: Computes SSHKey Secret Name
         path: workflow[0].computeSSHKeySecretName
-      - description: Container image for AnsibleTest
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: workflow[0].containerImage
       - description: Run ansible playbook with -vvvv
         displayName: Debug
         path: workflow[0].debug
-      - description: Extra configmaps for mounting in the pod
-        displayName: Extra Mounts
-        path: workflow[0].extraMounts
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: workflow[0].extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
         displayName: Mount Path
-        path: workflow[0].extraMounts[0].mountPath
+        path: workflow[0].extraConfigmapsMounts.mountPath
       - description: The name of an existing config map for mounting.
         displayName: Name
-        path: workflow[0].extraMounts[0].name
+        path: workflow[0].extraConfigmapsMounts.name
       - description: Config map subpath for mounting, defaults to configmap root.
         displayName: Sub Path
-        path: workflow[0].extraMounts[0].subPath
+        path: workflow[0].extraConfigmapsMounts.subPath
+      - description: This value contains a nodeSelector value that is applied to test
+          pods spawned by the test operator.
+        displayName: Node Selector
+        path: workflow[0].nodeSelector
       - description: OpenStackConfigMap is the name of the ConfigMap containing the
           clouds.yaml
         displayName: Open Stack Config Map
@@ -147,13 +168,25 @@ spec:
           secure.yaml
         displayName: Open Stack Config Secret
         path: workflow[0].openStackConfigSecret
+      - description: 'Use with caution! This parameter specifies whether test-operator
+          should spawn test pods with allowedPrivilegedEscalation: true and the default
+          capabilities on top of capabilities that are usually needed by the test
+          pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
+          for certain test-operator functionalities to work properly (e.g.: extraRPMs
+          in Tempest CR, or certain set of tobiko tests).'
+        displayName: Privileged
+        path: workflow[0].privileged
       - description: Name of a workflow step. The step name will be used for example
           to create a logs directory.
         displayName: Step Name
         path: workflow[0].stepName
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: workflow[0].storageClass
+      - description: This value contains a toleration that is applied to pods spawned
+          by the test pods that are spawned by the test-operator.
+        displayName: Tolerations
+        path: workflow[0].tolerations
       - description: WorkloadSSHKeySecretName is the name of the k8s secret that contains
           an ssh key for the ansible workload. The key is mounted to ~/test_keypair.key
           in the ansible pod
@@ -165,8 +198,7 @@ spec:
         displayName: Workload SSHKey Secret Name
         path: workloadSSHKeySecretName
       version: v1beta1
-    - description: HorizonTest is the Schema for the horizontests API
-      displayName: Horizon Test
+    - displayName: Horizon Test
       kind: HorizonTest
       name: horizontests.test.openstack.org
       specDescriptors:
@@ -179,18 +211,31 @@ spec:
       - description: AuthUrl is the authentication URL for OpenStack.
         displayName: Auth Url
         path: authUrl
-      - description: BackoffLimimt allows to define the maximum number of retried
-          executions.
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 0).
         displayName: Backoff Limit
         path: backoffLimit
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: Container image for horizontest
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: containerImage
       - description: DashboardUrl is the URL of the Horizon dashboard.
         displayName: Dashboard Url
         path: dashboardUrl
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: extraConfigmapsMounts
+      - description: Path within the container at which the volume should be mounted.
+        displayName: Mount Path
+        path: extraConfigmapsMounts[0].mountPath
+      - description: The name of an existing config map for mounting.
+        displayName: Name
+        path: extraConfigmapsMounts[0].name
+      - description: Config map subpath for mounting, defaults to configmap root.
+        displayName: Sub Path
+        path: extraConfigmapsMounts[0].subPath
       - description: FlavorName is the name of the OpenStack flavor to create for
           Horizon tests.
         displayName: Flavor Name
@@ -215,12 +260,24 @@ spec:
           logs.
         displayName: Logs Directory Name
         path: logsDirectoryName
+      - description: This value contains a nodeSelector value that is applied to test
+          pods spawned by the test operator.
+        displayName: Node Selector
+        path: nodeSelector
       - description: Parallel
         displayName: Parallel
         path: parallel
       - description: Password is the password for the user running the Horizon tests.
         displayName: Password
         path: password
+      - description: 'Use with caution! This parameter specifies whether test-operator
+          should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+          false, and the default capabilities on top of capabilities that are usually
+          needed by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+          but it is needed for certain test-operator functionalities to work properly
+          (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).'
+        displayName: Privileged
+        path: privileged
       - description: ProjectName is the name of the OpenStack project for Horizon
           tests.
         displayName: Project Name
@@ -228,15 +285,18 @@ spec:
       - description: RepoUrl is the URL of the Horizon repository.
         displayName: Repo Url
         path: repoUrl
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
+      - description: This value contains a toleration that is applied to pods spawned
+          by the test pods that are spawned by the test-operator.
+        displayName: Tolerations
+        path: tolerations
       - description: User is the username under which the Horizon tests will run.
         displayName: User
         path: user
       version: v1beta1
-    - description: Tempest is the Schema for the tempests API
-      displayName: Tempest
+    - displayName: Tempest
       kind: Tempest
       name: tempests.test.openstack.org
       specDescriptors:
@@ -247,19 +307,24 @@ spec:
           an ssh key. The key is mounted to ~/.ssh/id_ecdsa in the tempest pod
         displayName: SSHKey Secret Name
         path: SSHKeySecretName
-      - description: BackoffLimimt allows to define the maximum number of retried
-          executions (defaults to 6).
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 0).
         displayName: Backoff Limit
         path: backoffLimit
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Activate tempest cleanup. When activated, tempest will run tempest
+          cleanup after test execution is complete to delete any resources created
+          by tempest that may have been left out.
+        displayName: Cleanup
+        path: cleanup
       - description: ConfigOverwrite - interface to overwrite default config files
           like e.g. logging.conf But can also be used to add additional files. Those
           get added to the service config dir in /etc/test_operator/<file>
         displayName: Config Overwrite
         path: configOverwrite
-      - description: An URL of a tempest container image that should be used for the
-          execution of tempest tests.
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: containerImage
       - description: Activate debug mode. When debug mode is activated any error encountered
@@ -268,7 +333,7 @@ spec:
           This allows the user to debug any potential troubles with `oc rsh`.
         displayName: Debug
         path: debug
-      - description: Extra configmaps for mounting in the pod.
+      - description: Extra configmaps for mounting inside the pod
         displayName: Extra Configmaps Mounts
         path: extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -301,8 +366,15 @@ spec:
           turn off this behaviour then set this option to true.
         displayName: Parallel
         path: parallel
-      - description: Name of a storage class that is used to create PVCs for logs
-          storage. Required if default storage class does not exist.
+      - description: 'Use with caution! This parameter specifies whether test-operator
+          should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+          false, and the default capabilities on top of capabilities that are usually
+          needed by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+          but it is needed for certain test-operator functionalities to work properly
+          (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).'
+        displayName: Privileged
+        path: privileged
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
       - displayName: Tempest Run
@@ -502,8 +574,8 @@ spec:
           an ssh key. The key is mounted to ~/.ssh/id_ecdsa in the tempest pod
         displayName: SSHKey Secret Name
         path: workflow[0].SSHKeySecretName
-      - description: BackoffLimimt allows to define the maximum number of retried
-          executions (defaults to 6).
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 0).
         displayName: Backoff Limit
         path: workflow[0].backoffLimit
         x-descriptors:
@@ -513,10 +585,22 @@ spec:
           get added to the service config dir in /etc/test_operator/<file>
         displayName: Config Overwrite
         path: workflow[0].configOverwrite
-      - description: An URL of a tempest container image that should be used for the
-          execution of tempest tests.
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: workflow[0].containerImage
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: workflow[0].extraConfigmapsMounts
+      - description: Path within the container at which the volume should be mounted.
+        displayName: Mount Path
+        path: workflow[0].extraConfigmapsMounts.mountPath
+      - description: The name of an existing config map for mounting.
+        displayName: Name
+        path: workflow[0].extraConfigmapsMounts.name
+      - description: Config map subpath for mounting, defaults to configmap root.
+        displayName: Sub Path
+        path: workflow[0].extraConfigmapsMounts.subPath
       - description: NetworkAttachments is a list of NetworkAttachment resource names
           to expose the services to the given network
         displayName: Network Attachments
@@ -538,12 +622,19 @@ spec:
           turn off this behaviour then set this option to true.
         displayName: Parallel
         path: workflow[0].parallel
+      - description: 'Use with caution! This parameter specifies whether test-operator
+          should spawn test pods with allowedPrivilegedEscalation: true and the default
+          capabilities on top of capabilities that are usually needed by the test
+          pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
+          for certain test-operator functionalities to work properly (e.g.: extraRPMs
+          in Tempest CR, or certain set of tobiko tests).'
+        displayName: Privileged
+        path: workflow[0].privileged
       - description: Name of a workflow step. The step name will be used for example
           to create a logs directory.
         displayName: Step Name
         path: workflow[0].stepName
-      - description: Name of a storage class that is used to create PVCs for logs
-          storage. Required if default storage class does not exist.
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: workflow[0].storageClass
       - displayName: Tempest Run
@@ -732,13 +823,12 @@ spec:
         displayName: Tolerations
         path: workflow[0].tolerations
       version: v1beta1
-    - description: Tobiko is the Schema for the tobikoes API
-      displayName: Tobiko
+    - displayName: Tobiko
       kind: Tobiko
       name: tobikos.test.openstack.org
       specDescriptors:
-      - description: BackoffLimimt allows to define the maximum number of retried
-          executions (defaults to 6).
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 0).
         displayName: Backoff Limit
         path: backoffLimit
         x-descriptors:
@@ -746,9 +836,22 @@ spec:
       - description: tobiko.conf
         displayName: Config
         path: config
-      - description: Container image for tobiko
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: containerImage
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: extraConfigmapsMounts
+      - description: Path within the container at which the volume should be mounted.
+        displayName: Mount Path
+        path: extraConfigmapsMounts[0].mountPath
+      - description: The name of an existing config map for mounting.
+        displayName: Name
+        path: extraConfigmapsMounts[0].name
+      - description: Config map subpath for mounting, defaults to configmap root.
+        displayName: Sub Path
+        path: extraConfigmapsMounts[0].subPath
       - description: Name of a secret that contains a kubeconfig. The kubeconfig is
           mounted under /var/lib/tobiko/.kube/config in the test pod.
         displayName: Kubeconfig Secret Name
@@ -779,6 +882,14 @@ spec:
       - description: Private Key
         displayName: Private Key
         path: privateKey
+      - description: 'Use with caution! This parameter specifies whether test-operator
+          should spawn test pods with allowedPrivilegedEscalation: true, runAsNonRoot:
+          false, and the default capabilities on top of capabilities that are usually
+          needed by the test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure
+          but it is needed for certain test-operator functionalities to work properly
+          (e.g.: extraRPMs in Tempest CR, or certain set of tobiko tests).'
+        displayName: Privileged
+        path: privileged
       - description: Public Key
         displayName: Public Key
         path: publicKey
@@ -786,7 +897,7 @@ spec:
           tests
         displayName: Pytest Addopts
         path: pytestAddopts
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
       - description: Test environment
@@ -804,8 +915,8 @@ spec:
         path: workflow
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: BackoffLimimt allows to define the maximum number of retried
-          executions (defaults to 6).
+      - description: BackoffLimit allows to define the maximum number of retried executions
+          (defaults to 0).
         displayName: Backoff Limit
         path: workflow[0].backoffLimit
         x-descriptors:
@@ -813,9 +924,22 @@ spec:
       - description: tobiko.conf
         displayName: Config
         path: workflow[0].config
-      - description: Container image for tobiko
+      - description: A URL of a container image that should be used by the test-operator
+          for tests execution.
         displayName: Container Image
         path: workflow[0].containerImage
+      - description: Extra configmaps for mounting inside the pod
+        displayName: Extra Configmaps Mounts
+        path: workflow[0].extraConfigmapsMounts
+      - description: Path within the container at which the volume should be mounted.
+        displayName: Mount Path
+        path: workflow[0].extraConfigmapsMounts.mountPath
+      - description: The name of an existing config map for mounting.
+        displayName: Name
+        path: workflow[0].extraConfigmapsMounts.name
+      - description: Config map subpath for mounting, defaults to configmap root.
+        displayName: Sub Path
+        path: workflow[0].extraConfigmapsMounts.subPath
       - description: Name of a secret that contains a kubeconfig. The kubeconfig is
           mounted under /var/lib/tobiko/.kube/config in the test pod.
         displayName: Kubeconfig Secret Name
@@ -841,6 +965,14 @@ spec:
       - description: Private Key
         displayName: Private Key
         path: workflow[0].privateKey
+      - description: 'Use with caution! This parameter specifies whether test-operator
+          should spawn test pods with allowedPrivilegedEscalation: true and the default
+          capabilities on top of capabilities that are usually needed by the test
+          pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
+          for certain test-operator functionalities to work properly (e.g.: extraRPMs
+          in Tempest CR, or certain set of tobiko tests).'
+        displayName: Privileged
+        path: workflow[0].privileged
       - description: Public Key
         displayName: Public Key
         path: workflow[0].publicKey
@@ -853,7 +985,7 @@ spec:
         path: workflow[0].stepName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: StorageClass used to create PVCs that store the logs
+      - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: workflow[0].storageClass
       - description: Test environment

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -16,6 +16,7 @@ func GetSecurityContext(
 	securityContext := corev1.SecurityContext{
 		RunAsUser:                &runAsUser,
 		RunAsGroup:               &runAsUser,
+		RunAsNonRoot:             &trueVar,
 		AllowPrivilegeEscalation: &falseVar,
 		Capabilities: &corev1.Capabilities{
 			Add: addCapabilities,
@@ -26,6 +27,11 @@ func GetSecurityContext(
 	}
 
 	if privileged {
+		// Sometimes we require the test pods run sudo to be able to install
+		// additional packages or run commands with elevated priveleges (e.g.,
+		// tcpdump in case of Tobiko)
+		securityContext.RunAsNonRoot = &falseVar
+
 		// We need to run pods with AllowPrivilegedEscalation: true to remove
 		// nosuid from the pod (in order to be able to run sudo)
 		securityContext.AllowPrivilegeEscalation = &trueVar


### PR DESCRIPTION
This patch sets runAsNonRoot to true for each test pod by default. This parameter ensures that the pod runs as a non-root user.

It is possible the overwrite this behavior by setting privileged: true.