### PR TITLE
Change scope of test-operator to namespace

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -101,5 +101,10 @@ spec:
           requests:
             cpu: 10m
             memory: 128Mi
+        env:
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['olm.targetNamespaces']
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operatorframework.io/suggested-namespace: openstack
+    operatorframework.io/suggested-namespace: openstack-test-operator
   name: test-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,8 +1,9 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: manager-role
+  namespace: <namespace>
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: clusterrolebinding
@@ -11,7 +11,7 @@ metadata:
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount

--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -39,6 +39,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -51,19 +52,19 @@ func (r *AnsibleTestReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("AnsibleTest")
 }
 
-// +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=test.openstack.org,resources=ansibletests/finalizers,verbs=update;patch
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=ansibletests,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=ansibletests/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=ansibletests/finalizers,verbs=update;patch
+// +kubebuilder:rbac:groups=batch,namespace=<namespace>,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,namespace=<namespace>,resources=network-attachment-definitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",namespace=<namespace>,resources=roles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",namespace=<namespace>,resources=rolebindings,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="security.openshift.io",namespace=<namespace>,resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=secrets,namespace=<namespace>,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,namespace=<namespace>,verbs=get;list;watch;create;update;patch;delete;
+// +kubebuilder:rbac:groups="",resources=pods,namespace=<namespace>,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,namespace=<namespace>,verbs=get;list;create;update;watch;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,namespace=<namespace>,verbs=get;list;watch;create;update;patch
 
 // Reconcile - AnsibleTest
 func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -76,6 +77,7 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if k8s_errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
+
 		return ctrl.Result{}, err
 	}
 
@@ -298,6 +300,9 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // SetupWithManager sets up the controller with the Manager.
 func (r *AnsibleTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			CacheSyncTimeout: r.CacheSyncTimeout,
+		}).
 		For(&testv1beta1.AnsibleTest{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Secret{}).

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -66,10 +66,11 @@ const (
 )
 
 type Reconciler struct {
-	Client  client.Client
-	Kclient kubernetes.Interface
-	Log     logr.Logger
-	Scheme  *runtime.Scheme
+	CacheSyncTimeout time.Duration
+	Client           client.Client
+	Kclient          kubernetes.Interface
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
 }
 
 // NextAction holds an action that should be performed by the Reconcile loop.

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -48,19 +49,19 @@ func (r *HorizonTestReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("HorizonTest")
 }
 
-// +kubebuilder:rbac:groups=test.openstack.org,resources=horizontests,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=test.openstack.org,resources=horizontests/finalizers,verbs=update;patch
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=horizontests,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=horizontests/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=horizontests/finalizers,verbs=update;patch
+// +kubebuilder:rbac:groups=batch,namespace=<namespace>,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,namespace=<namespace>,resources=network-attachment-definitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",namespace=<namespace>,resources=roles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",namespace=<namespace>,resources=rolebindings,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="security.openshift.io",namespace=<namespace>,resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=secrets,namespace=<namespace>,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,namespace=<namespace>,verbs=get;list;watch;create;update;patch;delete;
+// +kubebuilder:rbac:groups="",resources=pods,namespace=<namespace>,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,namespace=<namespace>,verbs=get;list;create;update;watch;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,namespace=<namespace>,verbs=get;list;watch;create;update;patch
 
 // Reconcile - HorizonTest
 func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -285,6 +286,9 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // SetupWithManager sets up the controller with the Manager.
 func (r *HorizonTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			CacheSyncTimeout: r.CacheSyncTimeout,
+		}).
 		For(&testv1beta1.HorizonTest{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Secret{}).

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -40,6 +40,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -53,19 +54,19 @@ func (r *TempestReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("Tempest")
 }
 
-// +kubebuilder:rbac:groups=test.openstack.org,resources=tempests,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=test.openstack.org,resources=tempests/finalizers,verbs=update;patch
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=tempests,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=tempests/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=tempests/finalizers,verbs=update;patch
+// +kubebuilder:rbac:groups=batch,resources=jobs,namespace=<namespace>,verbs=get;list;watch;create;patch;update;delete;
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,namespace=<namespace>,resources=network-attachment-definitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",namespace=<namespace>,resources=roles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",namespace=<namespace>,resources=rolebindings,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="security.openshift.io",namespace=<namespace>,resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=secrets,namespace=<namespace>,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,namespace=<namespace>,verbs=get;list;watch;create;update;patch;delete;
+// +kubebuilder:rbac:groups="",resources=pods,namespace=<namespace>,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,namespace=<namespace>,verbs=get;list;create;update;watch;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,namespace=<namespace>,verbs=get;list;watch;create;update;patch
 
 // Reconcile - Tempest
 func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -424,6 +425,9 @@ func (r *TempestReconciler) reconcileDelete(
 // SetupWithManager sets up the controller with the Manager.
 func (r *TempestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			CacheSyncTimeout: r.CacheSyncTimeout,
+		}).
 		For(&testv1beta1.Tempest{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Secret{}).

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -40,6 +40,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -53,19 +54,19 @@ func (r *TobikoReconciler) GetLogger(ctx context.Context) logr.Logger {
 	return log.FromContext(ctx).WithName("Controllers").WithName("Tobiko")
 }
 
-// +kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=test.openstack.org,resources=tobikoes/finalizers,verbs=update;patch
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=tobikoes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=tobikoes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=test.openstack.org,namespace=<namespace>,resources=tobikoes/finalizers,verbs=update;patch
+// +kubebuilder:rbac:groups=batch,namespace=<namespace>,resources=jobs,verbs=get;list;watch;create;patch;update;delete;
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,namespace=<namespace>,resources=network-attachment-definitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",namespace=<namespace>,resources=roles,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",namespace=<namespace>,resources=rolebindings,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="security.openshift.io",namespace=<namespace>,resourceNames=anyuid;privileged;nonroot;nonroot-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",namespace=<namespace>,resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",namespace=<namespace>,resources=configmaps,verbs=get;list;watch;create;update;patch;delete;
+// +kubebuilder:rbac:groups="",namespace=<namespace>,resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",namespace=<namespace>,resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
+// +kubebuilder:rbac:groups="",namespace=<namespace>,resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 
 // Reconcile - Tobiko
 func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -77,6 +78,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		if k8s_errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
+
 		return ctrl.Result{}, err
 	}
 
@@ -374,6 +376,9 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 // SetupWithManager sets up the controller with the Manager.
 func (r *TobikoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			CacheSyncTimeout: r.CacheSyncTimeout,
+		}).
 		For(&testv1beta1.Tobiko{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Secret{}).


### PR DESCRIPTION
Test-operator is currently designed to be a cluster scoped operator. This means it can watch and modify resources across all OCP cluster.

This patch changes the operator to namespace scoped operator. By default it is going to watch only:

  - openstack-test-operator namespace: This is a namespace where we recommend to install the test-operator. Prior to the installation we recommend to create an OperatorGroup with targetNamespaces value set to openstack-test-operator and openstack.

  - openstack: This is a namespace where the openstack controll plane is deployed. Test-operator requires an access to this namespace in order to read openstack specific CMs and Secrets (e.g., clouds.yaml).