### PR TITLE
[zuul] Enable ansibletest and tobiko with stages

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -34,6 +34,13 @@
       # Test operator
       cifmw_test_operator_concurrency: 4
       cifmw_test_operator_timeout: 7200
+      cifmw_test_operator_stages:
+        - name: tempest
+          type: tempest
+        - name: tobiko
+          type: tobiko
+        - name: ansibletest
+          type: ansibletest
 
       # Tempest
       cifmw_run_tempest: true


### PR DESCRIPTION
With this PR in the test-operator role [1] we introduced the concept of stages. By default only tempest stage is enabled. In order for us to continue to test tobiko and ansibletest CR we have to explicitly enable the testing via the cifmw_test_operator_stages parameter.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2374