### PR TITLE
Add additional parameters for HorizonTest

### DIFF
--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -111,6 +111,11 @@ spec:
                   - subPath
                   type: object
                 type: array
+              extraFlag:
+                description: |-
+                  ExtraFlag is an extra flag that can be set to modify pytest command to
+                  exclude or include particular test(s)
+                type: string
               flavorName:
                 default: m1.tiny
                 description: FlavorName is the name of the OpenStack flavor to create
@@ -170,6 +175,11 @@ spec:
                 default: horizontest
                 description: ProjectName is the name of the OpenStack project for
                   Horizon tests.
+                type: string
+              projectNameXpath:
+                description: |-
+                  ProjectNameXpath is the xpath to select project name
+                  on the horizon dashboard based on the u/s or d/s theme
                 type: string
               repoUrl:
                 default: https://review.opendev.org/openstack/horizon

--- a/api/v1beta1/horizontest_types.go
+++ b/api/v1beta1/horizontest_types.go
@@ -42,6 +42,18 @@ type HorizonTestSpec struct {
 	// This allows the user to debug any potential troubles with `oc rsh`.
 	Debug bool `json:"debug"`
 
+	// ExtraFlag is an extra flag that can be set to modify pytest command to
+	// exclude or include particular test(s)
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	ExtraFlag string `json:"extraFlag"`
+
+	// ProjectNameXpath is the xpath to select project name
+	// on the horizon dashboard based on the u/s or d/s theme
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	ProjectNameXpath string `json:"projectNameXpath"`
+
 	// AdminUsername is the username for the OpenStack admin user.
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -111,6 +111,11 @@ spec:
                   - subPath
                   type: object
                 type: array
+              extraFlag:
+                description: |-
+                  ExtraFlag is an extra flag that can be set to modify pytest command to
+                  exclude or include particular test(s)
+                type: string
               flavorName:
                 default: m1.tiny
                 description: FlavorName is the name of the OpenStack flavor to create
@@ -170,6 +175,11 @@ spec:
                 default: horizontest
                 description: ProjectName is the name of the OpenStack project for
                   Horizon tests.
+                type: string
+              projectNameXpath:
+                description: |-
+                  ProjectNameXpath is the xpath to select project name
+                  on the horizon dashboard based on the u/s or d/s theme
                 type: string
               repoUrl:
                 default: https://review.opendev.org/openstack/horizon

--- a/config/samples/test_v1beta1_horizontest.yaml
+++ b/config/samples/test_v1beta1_horizontest.yaml
@@ -56,6 +56,12 @@ spec:
   # The maximum number of retry executions (optional)
   backoffLimit: 0
 
+  # The extra flag to modify pyTest commmand (optional)
+  extraFlag: "not pagination"
+
+  # ProjectNameXpath is the xpath to select project name on dashboard (optional)
+  projectNameXpath: "//span[@class='rcueicon rcueicon-folder-open']/ancestor::li"
+
   # Privileged
   # ----------
   #

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -293,6 +293,8 @@ func (r *HorizonTestReconciler) PrepareHorizonTestEnvVars(
 	envVars["FLAVOR_NAME"] = env.SetValue("m1.tiny")
 	envVars["HORIZON_KEYS_FOLDER"] = env.SetValue("/etc/test_operator")
 	envVars["HORIZONTEST_DEBUG_MODE"] = env.SetValue(r.GetDefaultBool(instance.Spec.Debug))
+	envVars["EXTRA_FLAG"] = env.SetValue(instance.Spec.ExtraFlag)
+	envVars["PROJECT_NAME_XPATH"] = env.SetValue(instance.Spec.ProjectNameXpath)
 
 	return envVars
 }


### PR DESCRIPTION
This PR adds additional paramaters to horizontest CR in order to modify the pytest command and projectname xpath based on upstream and downstream dashboard theme