### PR TITLE
Update deprecated artifacts

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -48,7 +48,7 @@ jobs:
           docs/build-docs.sh
       - name: Upload artifacts
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/build/html/
   deploy:
@@ -62,4 +62,4 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This patch updates deprecated artifacts for uploading pages. This should fix the error in Build Documentation check.