### PR TITLE
Change variable index to bundle

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,7 +10,7 @@
             dependencies:
               - openstack-k8s-operators-content-provider
             vars:
-              cifmw_test_operator_index: "{{ content_provider_registry_ip }}:5001/openstack-k8s-operators/test-operator-index:{{ zuul.patchset }}"
+              cifmw_test_operator_bundle: "{{ content_provider_registry_ip }}:5001/openstack-k8s-operators/test-operator:{{ zuul.patchset }}"
     periodic:
       jobs:
         - openstack-k8s-operators-content-provider:


### PR DESCRIPTION
Due to test-operator having a new method of installation, there is a need to change test-operator-index to test-operator-bundle.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2727