### PR TITLE
Fix network attachment binding

### DIFF
--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -279,39 +279,6 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			instance.Spec.NetworkAttachments, err)
 	}
 
-	// NetworkAttachments
-	if r.PodExists(ctx, instance, nextWorkflowStep) {
-		networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(
-			ctx,
-			helper,
-			instance.Spec.NetworkAttachments,
-			serviceLabels,
-			1,
-		)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
-		instance.Status.NetworkAttachments = networkAttachmentStatus
-
-		if networkReady {
-			instance.Status.Conditions.MarkTrue(
-				condition.NetworkAttachmentsReadyCondition,
-				condition.NetworkAttachmentsReadyMessage)
-		} else {
-			err := fmt.Errorf(ErrNetworkAttachments, instance.Spec.NetworkAttachments)
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.NetworkAttachmentsReadyCondition,
-				condition.ErrorReason,
-				condition.SeverityWarning,
-				condition.NetworkAttachmentsReadyErrorMessage,
-				err.Error()))
-
-			return ctrl.Result{}, err
-		}
-	}
-	// NetworkAttachments - end
-
 	// Create a new pod
 	mountCerts := r.CheckSecretExists(ctx, instance, "combined-ca-bundle")
 	customDataConfigMapName := GetCustomDataConfigMapName(instance, nextWorkflowStep)
@@ -381,6 +348,39 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrlResult, nil
 	}
 	// Create a new pod - end
+
+	// NetworkAttachments
+	if r.PodExists(ctx, instance, nextWorkflowStep) {
+		networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(
+			ctx,
+			helper,
+			instance.Spec.NetworkAttachments,
+			serviceLabels,
+			1,
+		)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		instance.Status.NetworkAttachments = networkAttachmentStatus
+
+		if networkReady {
+			instance.Status.Conditions.MarkTrue(
+				condition.NetworkAttachmentsReadyCondition,
+				condition.NetworkAttachmentsReadyMessage)
+		} else {
+			err := fmt.Errorf(ErrNetworkAttachments, instance.Spec.NetworkAttachments)
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.NetworkAttachmentsReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.NetworkAttachmentsReadyErrorMessage,
+				err.Error()))
+
+			return ctrl.Result{}, err
+		}
+	}
+	// NetworkAttachments - end
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
There is a problem with biding network attachments if the workflow is empty because of a wait loop. This patch aims to correctly bind network attachments before going into the wait loop.