### PR TITLE
Shorten test pod names

### DIFF
--- a/api/v1beta1/common_webhook.go
+++ b/api/v1beta1/common_webhook.go
@@ -7,6 +7,10 @@ const (
 
 	// ErrDebug
 	ErrDebug = "%s.Spec.Workflow parameter must be empty to run debug mode"
+
+	// ErrNameTooLong
+	ErrNameTooLong = "The combined length of %s pod name exceeds the maximum of %d " +
+		"characters. Shorten the CR name or workflow step name to proceed."
 )
 
 const (

--- a/api/v1beta1/tobiko_webhook.go
+++ b/api/v1beta1/tobiko_webhook.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -75,10 +76,36 @@ func (r *Tobiko) ValidateCreate() (admission.Warnings, error) {
 		})
 	}
 
+	if len(r.Name) >= validation.DNS1123LabelMaxLength {
+		allErrs = append(allErrs, &field.Error{
+			Type:     field.ErrorTypeInvalid,
+			BadValue: len(r.Name),
+			Detail:   fmt.Sprintf(ErrNameTooLong, "Tobiko", validation.DNS1123LabelMaxLength),
+		},
+		)
+	}
+
+	for _, workflowStep := range r.Spec.Workflow {
+		podNameLength := len(r.Name) + len(workflowStep.StepName) + len("-sXX-")
+
+		if podNameLength >= validation.DNS1123LabelMaxLength {
+			allErrs = append(allErrs, &field.Error{
+				Type:     field.ErrorTypeInvalid,
+				BadValue: podNameLength,
+				Detail:   fmt.Sprintf(ErrNameTooLong, "Tobiko", validation.DNS1123LabelMaxLength),
+			},
+			)
+		}
+	}
+
 	if r.Spec.Privileged {
 		allWarnings = append(allWarnings, fmt.Sprintf(WarnPrivilegedModeOn, "Tobiko"))
 	} else {
 		allWarnings = append(allWarnings, fmt.Sprintf(WarnPrivilegedModeOff, "Tobiko"))
+	}
+
+	if r.Spec.Privileged && len(r.Spec.Workflow) > 0 && len(r.Spec.SELinuxLevel) == 0 {
+		allWarnings = append(allWarnings, fmt.Sprintf(WarnSELinuxLevel, r.Kind))
 	}
 
 	if len(allErrs) > 0 {
@@ -87,10 +114,6 @@ func (r *Tobiko) ValidateCreate() (admission.Warnings, error) {
 				Group: GroupVersion.WithKind("Tobiko").Group,
 				Kind:  GroupVersion.WithKind("Tobiko").Kind,
 			}, r.GetName(), allErrs)
-	}
-
-	if r.Spec.Privileged && len(r.Spec.Workflow) > 0 && len(r.Spec.SELinuxLevel) == 0 {
-		allWarnings = append(allWarnings, fmt.Sprintf(WarnSELinuxLevel, r.Kind))
 	}
 
 	return allWarnings, nil

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -30,12 +30,11 @@ import (
 )
 
 const (
-	workflowNameSuffix       = "-workflow-counter"
-	podNameStepInfix         = "-workflow-step-"
-	envVarsConfigMapinfix    = "-env-vars-step-"
-	customDataConfigMapinfix = "-custom-data-step-"
+	podNameStepInfix         = "-s"
+	envVarsConfigMapinfix    = "-env-vars-s"
+	customDataConfigMapinfix = "-custom-data-s"
 	workflowStepNumInvalid   = -1
-	workflowStepNameInvalid  = "no-step-name"
+	workflowStepNameInvalid  = "no-name"
 	workflowStepLabel        = "workflowStep"
 	instanceNameLabel        = "instanceName"
 	operatorNameLabel        = "operator"
@@ -387,10 +386,6 @@ func (r *Reconciler) GetPodName(instance interface{}, workflowStepNum int) strin
 	}
 
 	return workflowStepNameInvalid
-}
-
-func (r *Reconciler) GetWorkflowConfigMapName(instance client.Object) string {
-	return instance.GetName() + workflowNameSuffix
 }
 
 func (r *Reconciler) GetPVCLogsName(instance client.Object, workflowStepNum int) string {


### PR DESCRIPTION
Openshift limits the length of a job name to 63 characters. To prevent the failure of jobs with long names, this patch introduces shortening of fixed infixes and suffixes.