### PR TITLE
Fix setting StorageClass parameter in main section

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -2231,7 +2231,6 @@ spec:
                       maxLength: 100
                       type: string
                     storageClass:
-                      default: local-storage
                       description: StorageClass used to create any test-operator related
                         PVCs.
                       type: string

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -2552,7 +2552,6 @@ spec:
                       pattern: ^[a-z0-9]
                       type: string
                     storageClass:
-                      default: local-storage
                       description: StorageClass used to create any test-operator related
                         PVCs.
                       type: string

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -2237,7 +2237,6 @@ spec:
                       maxLength: 100
                       type: string
                     storageClass:
-                      default: local-storage
                       description: StorageClass used to create any test-operator related
                         PVCs.
                       type: string

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -147,9 +147,8 @@ type WorkflowCommonOptions struct {
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="local-storage"
 	// StorageClass used to create any test-operator related PVCs.
-	StorageClass *string `json:"storageClass"`
+	StorageClass *string `json:"storageClass,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -2231,7 +2231,6 @@ spec:
                       maxLength: 100
                       type: string
                     storageClass:
-                      default: local-storage
                       description: StorageClass used to create any test-operator related
                         PVCs.
                       type: string

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -2552,7 +2552,6 @@ spec:
                       pattern: ^[a-z0-9]
                       type: string
                     storageClass:
-                      default: local-storage
                       description: StorageClass used to create any test-operator related
                         PVCs.
                       type: string

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -2237,7 +2237,6 @@ spec:
                       maxLength: 100
                       type: string
                     storageClass:
-                      default: local-storage
                       description: StorageClass used to create any test-operator related
                         PVCs.
                       type: string


### PR DESCRIPTION
Currently, it is not possible to set storageClass in the main section, if workflow is also set. The only possibility is to set storageClass individually for each step. This patch makes it possible to set storageClass parameter in the main section for every step.

Related-To: https://issues.redhat.com/browse/OSPRH-17024