### PR TITLE
Fix setting Resources parameter in main section

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -2161,13 +2161,6 @@ spec:
                         of tobiko tests).
                       type: boolean
                     resources:
-                      default:
-                        limits:
-                          cpu: 2000m
-                          memory: 2Gi
-                        requests:
-                          cpu: 1000m
-                          memory: 2Gi
                       description: |-
                         The desired amount of resources that should be assigned to each test pod
                         spawned using the AnsibleTest CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -2481,13 +2481,6 @@ spec:
                         of tobiko tests).
                       type: boolean
                     resources:
-                      default:
-                        limits:
-                          cpu: 8000m
-                          memory: 4Gi
-                        requests:
-                          cpu: 4000m
-                          memory: 2Gi
                       description: |-
                         The desired amount of resources that should be assigned to each test pod
                         spawned using the Tempest CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -2167,13 +2167,6 @@ spec:
                         when it runs tobiko tests
                       type: string
                     resources:
-                      default:
-                        limits:
-                          cpu: 8000m
-                          memory: 8Gi
-                        requests:
-                          cpu: 4000m
-                          memory: 4Gi
                       description: |-
                         The desired amount of resources that should be assigned to each test pod
                         spawned using the Tobiko CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements

--- a/api/v1beta1/ansibletest_types.go
+++ b/api/v1beta1/ansibletest_types.go
@@ -111,7 +111,6 @@ type AnsibleTestWorkflowSpec struct {
 
 	// The desired amount of resources that should be assigned to each test pod
 	// spawned using the AnsibleTest CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements
-	// +kubebuilder:default:={limits: {cpu: "2000m", memory: "2Gi"}, requests: {cpu: "1000m", memory: "2Gi"}}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1beta1/tempest_types_workflow.go
+++ b/api/v1beta1/tempest_types_workflow.go
@@ -232,7 +232,6 @@ type WorkflowTempestSpec struct {
 
 	// The desired amount of resources that should be assigned to each test pod
 	// spawned using the Tempest CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements
-	// +kubebuilder:default:={limits: {cpu: "8000m", memory: "4Gi"}, requests: {cpu: "4000m", memory: "2Gi"}}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// +kubebuilder:validation:Required

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -121,7 +121,6 @@ type TobikoSpec struct {
 type TobikoWorkflowSpec struct {
 	WorkflowCommonOptions `json:",inline"`
 
-	// +kubebuilder:default:={limits: {cpu: "8000m", memory: "8Gi"}, requests: {cpu: "4000m", memory: "4Gi"}}
 	// The desired amount of resources that should be assigned to each test pod
 	// spawned using the Tobiko CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -2161,13 +2161,6 @@ spec:
                         of tobiko tests).
                       type: boolean
                     resources:
-                      default:
-                        limits:
-                          cpu: 2000m
-                          memory: 2Gi
-                        requests:
-                          cpu: 1000m
-                          memory: 2Gi
                       description: |-
                         The desired amount of resources that should be assigned to each test pod
                         spawned using the AnsibleTest CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -2481,13 +2481,6 @@ spec:
                         of tobiko tests).
                       type: boolean
                     resources:
-                      default:
-                        limits:
-                          cpu: 8000m
-                          memory: 4Gi
-                        requests:
-                          cpu: 4000m
-                          memory: 2Gi
                       description: |-
                         The desired amount of resources that should be assigned to each test pod
                         spawned using the Tempest CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -2167,13 +2167,6 @@ spec:
                         when it runs tobiko tests
                       type: string
                     resources:
-                      default:
-                        limits:
-                          cpu: 8000m
-                          memory: 8Gi
-                        requests:
-                          cpu: 4000m
-                          memory: 4Gi
                       description: |-
                         The desired amount of resources that should be assigned to each test pod
                         spawned using the Tobiko CR. https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements


### PR DESCRIPTION
Update the WorkflowTempestSpec to not assign a default value to the Resources parameter. This lets the Resources value in the main section propagate into every workflow, which eliminates the need to set a custom value in every workflow.

Closes: [OSPRH-16131](https://issues.redhat.com//browse/OSPRH-16131)
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3037