### PR TITLE
Fixup POD_DEBUG var

### DIFF
--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -281,6 +281,8 @@ func (r *AnsibleTestReconciler) PrepareAnsibleEnv(
 	debug := instance.Spec.Debug
 	if debug {
 		envVars["POD_DEBUG"] = env.SetValue("true")
+	} else {
+		envVars["POD_DEBUG"] = env.SetValue("false")
 	}
 
 	// strings


### PR DESCRIPTION
According to the spec the default value for POD_DEBUG should be false but this value is not passed properly to the pod, so we end up using the default entrypoint script value (true).