### PR TITLE
Fix/update common.go to support Tobiko update flag

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -74,6 +74,13 @@ type CommonOptions struct {
 	// +kubebuilder:default:=""
 	// A URL of a container image that should be used by the test-operator for tests execution.
 	ContainerImage string `json:"containerImage"`
+        
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+        // +kubebuilder:validation:Optional
+        // +kubebuilder:default:=""
+        // A flag to indicate whether to update the Tobiko repo for test execution.
+        // If empty or set to "false", no update is performed.
+        TOBIKOUpdateRepo string `json:"tobikoUpdateRepo,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// BackoffLimit allows to define the maximum number of retried executions (defaults to 0).

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -74,13 +74,6 @@ type CommonOptions struct {
 	// +kubebuilder:default:=""
 	// A URL of a container image that should be used by the test-operator for tests execution.
 	ContainerImage string `json:"containerImage"`
-        
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-        // +kubebuilder:validation:Optional
-        // +kubebuilder:default:=""
-        // A flag to indicate whether to update the Tobiko repo for test execution.
-        // If empty or set to "false", no update is performed.
-        TOBIKOUpdateRepo string `json:"tobikoUpdateRepo,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// BackoffLimit allows to define the maximum number of retried executions (defaults to 0).

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -60,6 +60,12 @@ type TobikoSpec struct {
 	// Boolean specifying whether tobiko tests create new resources or re-use those previously created
 	PreventCreate bool `json:"preventCreate"`
 
+        // +kubebuilder:validation:Optional
+        // +operator-sdk:csv:customresourcedefinitions:type=spec
+        // +kubebuilder:default:=false
+        // Boolean flag to indicate whether to update the Tobiko repo before running tests.
+        UpdateRepo bool `json:"updateRepo"`
+
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:default:=4
@@ -139,6 +145,11 @@ type TobikoWorkflowSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// Boolean specifying whether tobiko tests create new resources or re-use those previously created
 	PreventCreate *bool `json:"preventCreate,omitempty"`
+
+	// +kubebuilder:validation:Optional
+        // +operator-sdk:csv:customresourcedefinitions:type=spec
+        // Boolean flag to indicate whether to update the Tobiko repo before running tests.
+        UpdateRepo *bool `json:"updateRepo,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -375,6 +375,13 @@ func (r *TobikoReconciler) PrepareTobikoEnvVars(
 	envVars["TOBIKO_VERSION"] = env.SetValue(instance.Spec.Version)
 	envVars["TOBIKO_PYTEST_ADDOPTS"] = env.SetValue(instance.Spec.PytestAddopts)
 
+        updateRepo := instance.Spec.UpdateRepo
+        if updateRepo {
+                envVars["TOBIKO_UPDATE_REPO"] = env.SetValue("True")
+        } else {
+                envVars["TOBIKO_UPDATE_REPO"] = env.SetValue("False")
+        }
+
 	preventCreate := instance.Spec.PreventCreate
 	if preventCreate {
 		envVars["TOBIKO_PREVENT_CREATE"] = env.SetValue("True")


### PR DESCRIPTION
A flag to indicate whether to update the Tobiko repo for test execution.
If empty or set to "false", no update is performed.