### PR TITLE
Replace deprecated 'cifmw_test_operator_concurrency' 

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -33,7 +33,6 @@
       cifmw_run_test_role: test_operator
 
       # Test operator
-      cifmw_test_operator_concurrency: 4
       cifmw_test_operator_timeout: 7200
       cifmw_test_operator_stages:
         - name: tempest
@@ -47,6 +46,7 @@
 
       # Tempest
       cifmw_run_tempest: true
+      cifmw_test_operator_tempest_concurrency: 4
       cifmw_test_operator_tempest_cleanup: true
       cifmw_test_operator_tempest_include_list: |
         ^tempest.


### PR DESCRIPTION
Replace deprecated 'cifmw_test_operator_concurrency' with 'cifmw_test_operator_tempest_concurrency'
This aligns with the DoD described in https://issues.redhat.com/browse/OSPRH-16755