### PR TITLE
Reuse timing data in Tempest

### DIFF
--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -1630,6 +1630,13 @@ spec:
                       executed with --verbose
                     type: boolean
                 type: object
+              timingDataUrl:
+                description: |-
+                  An URL pointing to an archive that contains the saved stestr timing data.
+                  This data is used to optimize the tests order, which helps to reduce the
+                  total Tempest execution time.
+                format: uri
+                type: string
               tolerations:
                 description: |-
                   This value contains a toleration that is applied to pods spawned by the
@@ -2152,6 +2159,13 @@ spec:
                             be executed with --verbose
                           type: boolean
                       type: object
+                    timingDataUrl:
+                      description: |-
+                        An URL pointing to an archive that contains the saved stestr timing data.
+                        This data is used to optimize the tests order, which helps to reduce the
+                        total Tempest execution time.
+                      format: uri
+                      type: string
                     tolerations:
                       description: |-
                         This value contains a toleration that is applied to pods spawned by the

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -443,6 +443,14 @@ type TempestSpec struct {
 	RerunOverrideStatus bool `json:"rerunOverrideStatus"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format=uri
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// An URL pointing to an archive that contains the saved stestr timing data.
+	// This data is used to optimize the tests order, which helps to reduce the
+	// total Tempest execution time.
+	TimingDataUrl string `json:"timingDataUrl,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose
 	// the services to the given network

--- a/api/v1beta1/tempest_types_workflow.go
+++ b/api/v1beta1/tempest_types_workflow.go
@@ -267,6 +267,14 @@ type WorkflowTempestSpec struct {
 	RerunOverrideStatus *bool `json:"rerunOverrideStatus,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format=uri
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// An URL pointing to an archive that contains the saved stestr timing data.
+	// This data is used to optimize the tests order, which helps to reduce the
+	// total Tempest execution time.
+	TimingDataUrl *string `json:"timingDataUrl,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose
 	// the services to the given network

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -853,6 +853,11 @@ func (in *WorkflowTempestSpec) DeepCopyInto(out *WorkflowTempestSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.TimingDataUrl != nil {
+		in, out := &in.TimingDataUrl, &out.TimingDataUrl
+		*out = new(string)
+		**out = **in
+	}
 	if in.NetworkAttachments != nil {
 		in, out := &in.NetworkAttachments, &out.NetworkAttachments
 		*out = new([]string)

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -1630,6 +1630,13 @@ spec:
                       executed with --verbose
                     type: boolean
                 type: object
+              timingDataUrl:
+                description: |-
+                  An URL pointing to an archive that contains the saved stestr timing data.
+                  This data is used to optimize the tests order, which helps to reduce the
+                  total Tempest execution time.
+                format: uri
+                type: string
               tolerations:
                 description: |-
                   This value contains a toleration that is applied to pods spawned by the
@@ -2152,6 +2159,13 @@ spec:
                             be executed with --verbose
                           type: boolean
                       type: object
+                    timingDataUrl:
+                      description: |-
+                        An URL pointing to an archive that contains the saved stestr timing data.
+                        This data is used to optimize the tests order, which helps to reduce the
+                        total Tempest execution time.
+                      format: uri
+                      type: string
                     tolerations:
                       description: |-
                         This value contains a toleration that is applied to pods spawned by the

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -593,6 +593,7 @@ func (r *TempestReconciler) generateServiceConfigMaps(
 	envVars["TEMPEST_CLEANUP"] = r.GetDefaultBool(instance.Spec.Cleanup)
 	envVars["TEMPEST_RERUN_FAILED_TESTS"] = r.GetDefaultBool(instance.Spec.RerunFailedTests)
 	envVars["TEMPEST_RERUN_OVERRIDE_STATUS"] = r.GetDefaultBool(instance.Spec.RerunOverrideStatus)
+	envVars["TEMPEST_TIMING_DATA_URL"] = instance.Spec.TimingDataUrl
 
 	cms := []util.Template{
 		// ConfigMap


### PR DESCRIPTION
We want to reuse timing data stored in the .stestr directory across multiple Tempest runs. This will help executed tempest tests to save time by optimizing the test order. This patch introduces a new parameter that will be used to specify where to find timing data to reuse.