### PR TITLE
Add support for tempest re-run feature

### DIFF
--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -1221,6 +1221,19 @@ spec:
                   needed for certain test-operator functionalities to work properly (e.g.:
                   extraRPMs in Tempest CR, or certain set of tobiko tests).
                 type: boolean
+              rerunFailedTests:
+                default: false
+                description: |-
+                  Activate tempest re-run feature. When activated, tempest will perform
+                  another run of the tests that failed during the first execution.
+                type: boolean
+              rerunOverrideStatus:
+                default: false
+                description: |-
+                  Allow override of exit status with the tempest re-run feature.
+                  When activated, the original return value of the tempest run will be
+                  overridden with a result of the tempest run on the set of failed tests.
+                type: boolean
               resources:
                 default:
                   limits:
@@ -1761,6 +1774,19 @@ spec:
                         This parameter is deemed insecure but it is needed for certain test-operator
                         functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                         of tobiko tests).
+                      type: boolean
+                    rerunFailedTests:
+                      default: false
+                      description: |-
+                        Activate tempest re-run feature. When activated, tempest will perform
+                        another run of the tests that failed during the first execution.
+                      type: boolean
+                    rerunOverrideStatus:
+                      default: false
+                      description: |-
+                        Allow override of exit status with the tempest re-run feature.
+                        When activated, the original return value of the tempest run will be
+                        overridden with a result of the tempest run on the set of failed tests.
                       type: boolean
                     resources:
                       description: |-

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -429,6 +429,21 @@ type TempestSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:default:=false
+	// Activate tempest re-run feature. When activated, tempest will perform
+	// another run of the tests that failed during the first execution.
+	RerunFailedTests bool `json:"rerunFailedTests"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:default:=false
+	// Allow override of exit status with the tempest re-run feature.
+	// When activated, the original return value of the tempest run will be
+	// overridden with a result of the tempest run on the set of failed tests.
+	RerunOverrideStatus bool `json:"rerunOverrideStatus"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose
 	// the services to the given network
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`

--- a/api/v1beta1/tempest_types_workflow.go
+++ b/api/v1beta1/tempest_types_workflow.go
@@ -255,6 +255,21 @@ type WorkflowTempestSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:default:=false
+	// Activate tempest re-run feature. When activated, tempest will perform
+	// another run of the tests that failed during the first execution.
+	RerunFailedTests bool `json:"rerunFailedTests"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:default:=false
+	// Allow override of exit status with the tempest re-run feature.
+	// When activated, the original return value of the tempest run will be
+	// overridden with a result of the tempest run on the set of failed tests.
+	RerunOverrideStatus bool `json:"rerunOverrideStatus"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose
 	// the services to the given network
 	NetworkAttachments *[]string `json:"networkAttachments,omitempty"`

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -1221,6 +1221,19 @@ spec:
                   needed for certain test-operator functionalities to work properly (e.g.:
                   extraRPMs in Tempest CR, or certain set of tobiko tests).
                 type: boolean
+              rerunFailedTests:
+                default: false
+                description: |-
+                  Activate tempest re-run feature. When activated, tempest will perform
+                  another run of the tests that failed during the first execution.
+                type: boolean
+              rerunOverrideStatus:
+                default: false
+                description: |-
+                  Allow override of exit status with the tempest re-run feature.
+                  When activated, the original return value of the tempest run will be
+                  overridden with a result of the tempest run on the set of failed tests.
+                type: boolean
               resources:
                 default:
                   limits:
@@ -1761,6 +1774,19 @@ spec:
                         This parameter is deemed insecure but it is needed for certain test-operator
                         functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
                         of tobiko tests).
+                      type: boolean
+                    rerunFailedTests:
+                      default: false
+                      description: |-
+                        Activate tempest re-run feature. When activated, tempest will perform
+                        another run of the tests that failed during the first execution.
+                      type: boolean
+                    rerunOverrideStatus:
+                      default: false
+                      description: |-
+                        Allow override of exit status with the tempest re-run feature.
+                        When activated, the original return value of the tempest run will be
+                        overridden with a result of the tempest run on the set of failed tests.
                       type: boolean
                     resources:
                       description: |-

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -591,6 +591,8 @@ func (r *TempestReconciler) generateServiceConfigMaps(
 
 	envVars["TEMPEST_DEBUG_MODE"] = r.GetDefaultBool(instance.Spec.Debug)
 	envVars["TEMPEST_CLEANUP"] = r.GetDefaultBool(instance.Spec.Cleanup)
+	envVars["TEMPEST_RERUN_FAILED_TESTS"] = r.GetDefaultBool(instance.Spec.RerunFailedTests)
+	envVars["TEMPEST_RERUN_OVERRIDE_STATUS"] = r.GetDefaultBool(instance.Spec.RerunOverrideStatus)
 
 	cms := []util.Template{
 		// ConfigMap


### PR DESCRIPTION
The tempest runner script has recently got a feature that allows re-running the failed tests – for having additional insight on the issues repeatability. This commit adds the support of enabling that feature from the test-operator perspective.

Related: https://github.com/openstack-k8s-operators/tcib/pull/320