### PR TITLE
Fix naming inconsistency in AnsibleTest

### DIFF
--- a/api/v1beta1/ansibletest_types.go
+++ b/api/v1beta1/ansibletest_types.go
@@ -38,7 +38,7 @@ type AnsibleTestSpec struct {
 	// +kubebuilder:default:="dataplane-ansible-ssh-private-key-secret"
 	// ComputeSSHKeySecretName is the name of the k8s secret that contains an ssh key for computes.
 	// The key is mounted to ~/.ssh/id_ecdsa in the ansible pod
-	ComputesSSHKeySecretName string `json:"computeSSHKeySecretName"`
+	ComputeSSHKeySecretName string `json:"computeSSHKeySecretName"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxLength=253
@@ -119,7 +119,7 @@ type AnsibleTestWorkflowSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// ComputeSSHKeySecretName is the name of the k8s secret that contains an ssh key for computes.
 	// The key is mounted to ~/.ssh/id_ecdsa in the ansible pod
-	ComputesSSHKeySecretName string `json:"computeSSHKeySecretName"`
+	ComputeSSHKeySecretName string `json:"computeSSHKeySecretName"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxLength=253

--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -274,7 +274,7 @@ func (r *AnsibleTestReconciler) PrepareAnsibleEnv(
 
 	// volumes workflow override
 	workflowOverrideParams["WorkloadSSHKeySecretName"] = instance.Spec.WorkloadSSHKeySecretName
-	workflowOverrideParams["ComputesSSHKeySecretName"] = instance.Spec.ComputesSSHKeySecretName
+	workflowOverrideParams["ComputeSSHKeySecretName"] = instance.Spec.ComputeSSHKeySecretName
 	workflowOverrideParams["ContainerImage"] = instance.Spec.ContainerImage
 
 	// bool

--- a/pkg/ansibletest/volumes.go
+++ b/pkg/ansibletest/volumes.go
@@ -85,7 +85,7 @@ func GetVolumes(
 		Name: "compute-ssh-secret",
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName:  workflowOverrideParams["ComputesSSHKeySecretName"],
+				SecretName:  workflowOverrideParams["ComputeSSHKeySecretName"],
 				DefaultMode: &privateKeyMode,
 			},
 		},


### PR DESCRIPTION
The parameter ComputeSSHKeySecretName had an extra s defined, while the comment and json variant didn't. To keep code consistent, we should make them the same.