### PR TITLE
Fix empty AnsibleTest workload key

### DIFF
--- a/pkg/ansibletest/volumes.go
+++ b/pkg/ansibletest/volumes.go
@@ -93,17 +93,19 @@ func GetVolumes(
 
 	volumes = append(volumes, keysVolume)
 
-	keysVolume = corev1.Volume{
-		Name: "workload-ssh-secret",
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName:  workflowOverrideParams["WorkloadSSHKeySecretName"],
-				DefaultMode: &privateKeyMode,
+	if workflowOverrideParams["WorkloadSSHKeySecretName"] != "" {
+		keysVolume = corev1.Volume{
+			Name: "workload-ssh-secret",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  workflowOverrideParams["WorkloadSSHKeySecretName"],
+					DefaultMode: &privateKeyMode,
+				},
 			},
-		},
-	}
+		}
 
-	volumes = append(volumes, keysVolume)
+		volumes = append(volumes, keysVolume)
+	}
 
 	for _, exv := range instance.Spec.ExtraMounts {
 		for _, vol := range exv.Propagate(svc) {


### PR DESCRIPTION
Currently, if user doesn't specify the WorkloadSSHKeySecretName in AnsibleTest CR type, the pod creation is stuck. The reason is that the test-operator is always trying to mount the workload-ssh-secret Secret, but the default is an empty string.