### PR TITLE
Add warning for ExtraConfigmapsMounts deprecation

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -106,8 +106,14 @@ spec:
                 description: Run ansible playbook with -vvvv
                 type: boolean
               extraConfigmapsMounts:
-                description: Extra configmaps for mounting inside the pod
+                description: |-
+                  Extra configmaps for mounting inside the pod
+                  WARNING: This parameter will be deprecated!
+                  Please use ExtraMounts parameter instead!
                 items:
+                  description: |-
+                    WARNING: This parameter will be deprecated!
+                    Please use ExtraMounts parameter instead!
                   properties:
                     mountPath:
                       description: Path within the container at which the volume should
@@ -1383,8 +1389,14 @@ spec:
                       description: Run ansible playbook with -vvvv
                       type: boolean
                     extraConfigmapsMounts:
-                      description: Extra configmaps for mounting inside the pod
+                      description: |-
+                        Extra configmaps for mounting inside the pod
+                        WARNING: This parameter will be deprecated!
+                        Please use ExtraMounts parameter instead!
                       items:
+                        description: |-
+                          WARNING: This parameter will be deprecated!
+                          Please use ExtraMounts parameter instead!
                         properties:
                           mountPath:
                             description: Path within the container at which the volume

--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -95,8 +95,14 @@ spec:
                   This allows the user to debug any potential troubles with `oc rsh`.
                 type: boolean
               extraConfigmapsMounts:
-                description: Extra configmaps for mounting inside the pod
+                description: |-
+                  Extra configmaps for mounting inside the pod
+                  WARNING: This parameter will be deprecated!
+                  Please use ExtraMounts parameter instead!
                 items:
+                  description: |-
+                    WARNING: This parameter will be deprecated!
+                    Please use ExtraMounts parameter instead!
                   properties:
                     mountPath:
                       description: Path within the container at which the volume should

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -96,8 +96,14 @@ spec:
                   This allows the user to debug any potential troubles with `oc rsh`.
                 type: boolean
               extraConfigmapsMounts:
-                description: Extra configmaps for mounting inside the pod
+                description: |-
+                  Extra configmaps for mounting inside the pod
+                  WARNING: This parameter will be deprecated!
+                  Please use ExtraMounts parameter instead!
                 items:
+                  description: |-
+                    WARNING: This parameter will be deprecated!
+                    Please use ExtraMounts parameter instead!
                   properties:
                     mountPath:
                       description: Path within the container at which the volume should
@@ -1721,8 +1727,14 @@ spec:
                         by the test-operator for tests execution.
                       type: string
                     extraConfigmapsMounts:
-                      description: Extra configmaps for mounting inside the pod
+                      description: |-
+                        Extra configmaps for mounting inside the pod
+                        WARNING: This parameter will be deprecated!
+                        Please use ExtraMounts parameter instead!
                       items:
+                        description: |-
+                          WARNING: This parameter will be deprecated!
+                          Please use ExtraMounts parameter instead!
                         properties:
                           mountPath:
                             description: Path within the container at which the volume

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -77,8 +77,14 @@ spec:
                   This allows the user to debug any potential troubles with `oc rsh`.
                 type: boolean
               extraConfigmapsMounts:
-                description: Extra configmaps for mounting inside the pod
+                description: |-
+                  Extra configmaps for mounting inside the pod
+                  WARNING: This parameter will be deprecated!
+                  Please use ExtraMounts parameter instead!
                 items:
+                  description: |-
+                    WARNING: This parameter will be deprecated!
+                    Please use ExtraMounts parameter instead!
                   properties:
                     mountPath:
                       description: Path within the container at which the volume should
@@ -1377,8 +1383,14 @@ spec:
                         by the test-operator for tests execution.
                       type: string
                     extraConfigmapsMounts:
-                      description: Extra configmaps for mounting inside the pod
+                      description: |-
+                        Extra configmaps for mounting inside the pod
+                        WARNING: This parameter will be deprecated!
+                        Please use ExtraMounts parameter instead!
                       items:
+                        description: |-
+                          WARNING: This parameter will be deprecated!
+                          Please use ExtraMounts parameter instead!
                         properties:
                           mountPath:
                             description: Path within the container at which the volume

--- a/api/v1beta1/ansibletest_webhook.go
+++ b/api/v1beta1/ansibletest_webhook.go
@@ -88,6 +88,16 @@ func (r *AnsibleTest) ValidateCreate() (admission.Warnings, error) {
 			},
 			)
 		}
+
+		if workflowStep.ExtraConfigmapsMounts != nil {
+			allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
+				"deprecated! Please use ExtraMounts parameter instead!")
+		}
+	}
+
+	if len(r.Spec.ExtraConfigmapsMounts) > 0 {
+		allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
+			"deprecated! Please use ExtraMounts parameter instead!")
 	}
 
 	if r.Spec.Privileged {

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// WARNING: This parameter will be deprecated!
+// Please use ExtraMounts parameter instead!
 type ExtraConfigmapsMounts struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Required
@@ -84,6 +86,8 @@ type CommonOptions struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Optional
 	// Extra configmaps for mounting inside the pod
+	// WARNING: This parameter will be deprecated!
+	// Please use ExtraMounts parameter instead!
 	ExtraConfigmapsMounts []ExtraConfigmapsMounts `json:"extraConfigmapsMounts,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
@@ -172,6 +176,8 @@ type WorkflowCommonOptions struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Optional
 	// Extra configmaps for mounting inside the pod
+	// WARNING: This parameter will be deprecated!
+	// Please use ExtraMounts parameter instead!
 	ExtraConfigmapsMounts *[]ExtraConfigmapsMounts `json:"extraConfigmapsMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/horizontest_webhook.go
+++ b/api/v1beta1/horizontest_webhook.go
@@ -63,6 +63,11 @@ func (r *HorizonTest) ValidateCreate() (admission.Warnings, error) {
 
 	var allWarnings admission.Warnings
 
+	if len(r.Spec.ExtraConfigmapsMounts) > 0 {
+		allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
+			"deprecated! Please use ExtraMounts parameter instead!")
+	}
+
 	if r.Spec.Privileged {
 		allWarnings = append(allWarnings, fmt.Sprintf(WarnPrivilegedModeOn, "HorizonTest"))
 	}

--- a/api/v1beta1/tempest_webhook.go
+++ b/api/v1beta1/tempest_webhook.go
@@ -129,6 +129,16 @@ func (r *Tempest) ValidateCreate() (admission.Warnings, error) {
 			},
 			)
 		}
+
+		if workflowStep.ExtraConfigmapsMounts != nil {
+			allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
+				"deprecated! Please use ExtraMounts parameter instead!")
+		}
+	}
+
+	if len(r.Spec.ExtraConfigmapsMounts) > 0 {
+		allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
+			"deprecated! Please use ExtraMounts parameter instead!")
 	}
 
 	if r.Spec.Privileged {

--- a/api/v1beta1/tobiko_webhook.go
+++ b/api/v1beta1/tobiko_webhook.go
@@ -96,6 +96,16 @@ func (r *Tobiko) ValidateCreate() (admission.Warnings, error) {
 			},
 			)
 		}
+
+		if workflowStep.ExtraConfigmapsMounts != nil {
+			allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
+				"deprecated! Please use ExtraMounts parameter instead!")
+		}
+	}
+
+	if len(r.Spec.ExtraConfigmapsMounts) > 0 {
+		allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
+			"deprecated! Please use ExtraMounts parameter instead!")
 	}
 
 	if r.Spec.Privileged {

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -106,8 +106,14 @@ spec:
                 description: Run ansible playbook with -vvvv
                 type: boolean
               extraConfigmapsMounts:
-                description: Extra configmaps for mounting inside the pod
+                description: |-
+                  Extra configmaps for mounting inside the pod
+                  WARNING: This parameter will be deprecated!
+                  Please use ExtraMounts parameter instead!
                 items:
+                  description: |-
+                    WARNING: This parameter will be deprecated!
+                    Please use ExtraMounts parameter instead!
                   properties:
                     mountPath:
                       description: Path within the container at which the volume should
@@ -1383,8 +1389,14 @@ spec:
                       description: Run ansible playbook with -vvvv
                       type: boolean
                     extraConfigmapsMounts:
-                      description: Extra configmaps for mounting inside the pod
+                      description: |-
+                        Extra configmaps for mounting inside the pod
+                        WARNING: This parameter will be deprecated!
+                        Please use ExtraMounts parameter instead!
                       items:
+                        description: |-
+                          WARNING: This parameter will be deprecated!
+                          Please use ExtraMounts parameter instead!
                         properties:
                           mountPath:
                             description: Path within the container at which the volume

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -95,8 +95,14 @@ spec:
                   This allows the user to debug any potential troubles with `oc rsh`.
                 type: boolean
               extraConfigmapsMounts:
-                description: Extra configmaps for mounting inside the pod
+                description: |-
+                  Extra configmaps for mounting inside the pod
+                  WARNING: This parameter will be deprecated!
+                  Please use ExtraMounts parameter instead!
                 items:
+                  description: |-
+                    WARNING: This parameter will be deprecated!
+                    Please use ExtraMounts parameter instead!
                   properties:
                     mountPath:
                       description: Path within the container at which the volume should

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -96,8 +96,14 @@ spec:
                   This allows the user to debug any potential troubles with `oc rsh`.
                 type: boolean
               extraConfigmapsMounts:
-                description: Extra configmaps for mounting inside the pod
+                description: |-
+                  Extra configmaps for mounting inside the pod
+                  WARNING: This parameter will be deprecated!
+                  Please use ExtraMounts parameter instead!
                 items:
+                  description: |-
+                    WARNING: This parameter will be deprecated!
+                    Please use ExtraMounts parameter instead!
                   properties:
                     mountPath:
                       description: Path within the container at which the volume should
@@ -1721,8 +1727,14 @@ spec:
                         by the test-operator for tests execution.
                       type: string
                     extraConfigmapsMounts:
-                      description: Extra configmaps for mounting inside the pod
+                      description: |-
+                        Extra configmaps for mounting inside the pod
+                        WARNING: This parameter will be deprecated!
+                        Please use ExtraMounts parameter instead!
                       items:
+                        description: |-
+                          WARNING: This parameter will be deprecated!
+                          Please use ExtraMounts parameter instead!
                         properties:
                           mountPath:
                             description: Path within the container at which the volume

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -77,8 +77,14 @@ spec:
                   This allows the user to debug any potential troubles with `oc rsh`.
                 type: boolean
               extraConfigmapsMounts:
-                description: Extra configmaps for mounting inside the pod
+                description: |-
+                  Extra configmaps for mounting inside the pod
+                  WARNING: This parameter will be deprecated!
+                  Please use ExtraMounts parameter instead!
                 items:
+                  description: |-
+                    WARNING: This parameter will be deprecated!
+                    Please use ExtraMounts parameter instead!
                   properties:
                     mountPath:
                       description: Path within the container at which the volume should
@@ -1377,8 +1383,14 @@ spec:
                         by the test-operator for tests execution.
                       type: string
                     extraConfigmapsMounts:
-                      description: Extra configmaps for mounting inside the pod
+                      description: |-
+                        Extra configmaps for mounting inside the pod
+                        WARNING: This parameter will be deprecated!
+                        Please use ExtraMounts parameter instead!
                       items:
+                        description: |-
+                          WARNING: This parameter will be deprecated!
+                          Please use ExtraMounts parameter instead!
                         properties:
                           mountPath:
                             description: Path within the container at which the volume

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ spec:
       - description: ComputeSSHKeySecretName is the name of the k8s secret that contains
           an ssh key for computes. The key is mounted to ~/.ssh/id_ecdsa in the ansible
           pod
-        displayName: Computes SSHKey Secret Name
+        displayName: Compute SSHKey Secret Name
         path: computeSSHKeySecretName
       - description: A URL of a container image that should be used by the test-operator
           for tests execution.
@@ -65,7 +65,8 @@ spec:
       - description: Run ansible playbook with -vvvv
         displayName: Debug
         path: debug
-      - description: Extra configmaps for mounting inside the pod
+      - description: 'Extra configmaps for mounting inside the pod WARNING: This parameter
+          will be deprecated! Please use ExtraMounts parameter instead!'
         displayName: Extra Configmaps Mounts
         path: extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -154,7 +155,7 @@ spec:
       - description: ComputeSSHKeySecretName is the name of the k8s secret that contains
           an ssh key for computes. The key is mounted to ~/.ssh/id_ecdsa in the ansible
           pod
-        displayName: Computes SSHKey Secret Name
+        displayName: Compute SSHKey Secret Name
         path: workflow[0].computeSSHKeySecretName
       - description: A URL of a container image that should be used by the test-operator
           for tests execution.
@@ -163,7 +164,8 @@ spec:
       - description: Run ansible playbook with -vvvv
         displayName: Debug
         path: workflow[0].debug
-      - description: Extra configmaps for mounting inside the pod
+      - description: 'Extra configmaps for mounting inside the pod WARNING: This parameter
+          will be deprecated! Please use ExtraMounts parameter instead!'
         displayName: Extra Configmaps Mounts
         path: workflow[0].extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -247,7 +249,8 @@ spec:
       - description: DashboardUrl is the URL of the Horizon dashboard.
         displayName: Dashboard Url
         path: dashboardUrl
-      - description: Extra configmaps for mounting inside the pod
+      - description: 'Extra configmaps for mounting inside the pod WARNING: This parameter
+          will be deprecated! Please use ExtraMounts parameter instead!'
         displayName: Extra Configmaps Mounts
         path: extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -375,7 +378,8 @@ spec:
           This allows the user to debug any potential troubles with `oc rsh`.
         displayName: Debug
         path: debug
-      - description: Extra configmaps for mounting inside the pod
+      - description: 'Extra configmaps for mounting inside the pod WARNING: This parameter
+          will be deprecated! Please use ExtraMounts parameter instead!'
         displayName: Extra Configmaps Mounts
         path: extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -664,7 +668,8 @@ spec:
           for tests execution.
         displayName: Container Image
         path: workflow[0].containerImage
-      - description: Extra configmaps for mounting inside the pod
+      - description: 'Extra configmaps for mounting inside the pod WARNING: This parameter
+          will be deprecated! Please use ExtraMounts parameter instead!'
         displayName: Extra Configmaps Mounts
         path: workflow[0].extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -938,7 +943,8 @@ spec:
           for tests execution.
         displayName: Container Image
         path: containerImage
-      - description: Extra configmaps for mounting inside the pod
+      - description: 'Extra configmaps for mounting inside the pod WARNING: This parameter
+          will be deprecated! Please use ExtraMounts parameter instead!'
         displayName: Extra Configmaps Mounts
         path: extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.
@@ -1043,7 +1049,8 @@ spec:
           for tests execution.
         displayName: Container Image
         path: workflow[0].containerImage
-      - description: Extra configmaps for mounting inside the pod
+      - description: 'Extra configmaps for mounting inside the pod WARNING: This parameter
+          will be deprecated! Please use ExtraMounts parameter instead!'
         displayName: Extra Configmaps Mounts
         path: workflow[0].extraConfigmapsMounts
       - description: Path within the container at which the volume should be mounted.

--- a/config/samples/test_v1beta1_ansibletest.yaml
+++ b/config/samples/test_v1beta1_ansibletest.yaml
@@ -33,6 +33,19 @@ spec:
   # of tobiko tests).
   #
   # privileged: false
+  #
+  # extraMounts:
+  #   - extraVol:
+  #     - propagation:
+  #         - AnsibleTest
+  #       extraVolType: ConfigMap
+  #       volumes:
+  #         - name: configmap-volume
+  #           configMap:
+  #             name: configmap-name
+  #       mounts:
+  #         - name: configmap-volume
+  #           mountPath: "/etc/config"
 
   # resources:
   #   limits:

--- a/config/samples/test_v1beta1_horizontest.yaml
+++ b/config/samples/test_v1beta1_horizontest.yaml
@@ -73,6 +73,19 @@ spec:
   # of tobiko tests).
   #
   # privileged: false
+  #
+  # extraMounts:
+  #   - extraVol:
+  #     - propagation:
+  #         - HorizonTest
+  #       extraVolType: ConfigMap
+  #       volumes:
+  #         - name: configmap-volume
+  #           configMap:
+  #             name: configmap-name
+  #       mounts:
+  #         - name: configmap-volume
+  #           mountPath: "/etc/config"
 
   # resources:
   #   limits:

--- a/config/samples/test_v1beta1_tempest.yaml
+++ b/config/samples/test_v1beta1_tempest.yaml
@@ -38,7 +38,20 @@ spec:
   # or certain set tobiko tests).
   #
   # privileged: false
-
+  #
+  # extraMounts:
+  #   - extraVol:
+  #     - propagation:
+  #         - Tempest
+  #       extraVolType: ConfigMap
+  #       volumes:
+  #         - name: configmap-volume
+  #           configMap:
+  #             name: configmap-name
+  #       mounts:
+  #         - name: configmap-volume
+  #           mountPath: "/etc/config"
+  #
   # resources:
   #   limits:
   #     cpu: 8000m

--- a/config/samples/test_v1beta1_tobiko.yaml
+++ b/config/samples/test_v1beta1_tobiko.yaml
@@ -18,6 +18,19 @@ spec:
   # of tobiko tests).
   #
   # privileged: false
+  #
+  # extraMounts:
+  #   - extraVol:
+  #     - propagation:
+  #         - Tobiko
+  #       extraVolType: ConfigMap
+  #       volumes:
+  #         - name: configmap-volume
+  #           configMap:
+  #             name: configmap-name
+  #       mounts:
+  #         - name: configmap-volume
+  #           mountPath: "/etc/config"
 
   # storageClass: local-storage
   # parallel: false


### PR DESCRIPTION
Now that test-operator supports ExtraMounts parameter, there is no need for a parameter adding extra configmap mounts. It can be directly done through ExtraMounts, so I think of it as a duplicate code. But it is not a good practice to remove parameters right away, so I am first adding warning for users who might be using extraConfigmapsMounts parameters about its deprecation. Let's remove it after this warning is old enough.