### PR TITLE
[ansibletest] Add ansibleGitBranch option

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -63,6 +63,11 @@ spec:
                 default: ""
                 description: AnsibleExtraVars - string to pass parameters to ansible
                 type: string
+              ansibleGitBranch:
+                description: AnsibleGitBranch - git branch to check out in the cloned
+                  repo
+                format: string
+                type: string
               ansibleGitRepo:
                 description: AnsibleGitRepo - git repo to clone into container
                 format: uri
@@ -1344,6 +1349,11 @@ spec:
                     ansibleExtraVars:
                       description: AnsibleExtraVars - interface to pass parameters
                         to ansible using -e
+                      type: string
+                    ansibleGitBranch:
+                      description: AnsibleGitBranch - git branch to check out in the
+                        cloned repo
+                      format: string
                       type: string
                     ansibleGitRepo:
                       description: AnsibleGitRepo - git repo to clone into container

--- a/api/v1beta1/ansibletest_types.go
+++ b/api/v1beta1/ansibletest_types.go
@@ -54,6 +54,12 @@ type AnsibleTestSpec struct {
 	// AnsibleGitRepo - git repo to clone into container
 	AnsibleGitRepo string `json:"ansibleGitRepo"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format=string
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// AnsibleGitBranch - git branch to check out in the cloned repo
+	AnsibleGitBranch string `json:"ansibleGitBranch,omitEmpty"`
+
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:default:=""
@@ -133,6 +139,12 @@ type AnsibleTestWorkflowSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// AnsibleGitRepo - git repo to clone into container
 	AnsibleGitRepo string `json:"ansibleGitRepo,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format=string
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// AnsibleGitBranch - git branch to check out in the cloned repo
+	AnsibleGitBranch string `json:"ansibleGitBranch,omitEmpty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -63,6 +63,11 @@ spec:
                 default: ""
                 description: AnsibleExtraVars - string to pass parameters to ansible
                 type: string
+              ansibleGitBranch:
+                description: AnsibleGitBranch - git branch to check out in the cloned
+                  repo
+                format: string
+                type: string
               ansibleGitRepo:
                 description: AnsibleGitRepo - git repo to clone into container
                 format: uri
@@ -1344,6 +1349,11 @@ spec:
                     ansibleExtraVars:
                       description: AnsibleExtraVars - interface to pass parameters
                         to ansible using -e
+                      type: string
+                    ansibleGitBranch:
+                      description: AnsibleGitBranch - git branch to check out in the
+                        cloned repo
+                      format: string
                       type: string
                     ansibleGitRepo:
                       description: AnsibleGitRepo - git repo to clone into container

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -33,6 +33,9 @@ spec:
       - description: AnsibleExtraVars - string to pass parameters to ansible
         displayName: Ansible Extra Vars
         path: ansibleExtraVars
+      - description: AnsibleGitBranch - git branch to check out in the cloned repo
+        displayName: Ansible Git Branch
+        path: ansibleGitBranch
       - description: AnsibleGitRepo - git repo to clone into container
         displayName: Ansible Git Repo
         path: ansibleGitRepo
@@ -56,7 +59,7 @@ spec:
       - description: ComputeSSHKeySecretName is the name of the k8s secret that contains
           an ssh key for computes. The key is mounted to ~/.ssh/id_ecdsa in the ansible
           pod
-        displayName: Computes SSHKey Secret Name
+        displayName: Compute SSHKey Secret Name
         path: computeSSHKeySecretName
       - description: A URL of a container image that should be used by the test-operator
           for tests execution.
@@ -131,6 +134,9 @@ spec:
           -e
         displayName: Ansible Extra Vars
         path: workflow[0].ansibleExtraVars
+      - description: AnsibleGitBranch - git branch to check out in the cloned repo
+        displayName: Ansible Git Branch
+        path: workflow[0].ansibleGitBranch
       - description: AnsibleGitRepo - git repo to clone into container
         displayName: Ansible Git Repo
         path: workflow[0].ansibleGitRepo
@@ -154,7 +160,7 @@ spec:
       - description: ComputeSSHKeySecretName is the name of the k8s secret that contains
           an ssh key for computes. The key is mounted to ~/.ssh/id_ecdsa in the ansible
           pod
-        displayName: Computes SSHKey Secret Name
+        displayName: Compute SSHKey Secret Name
         path: workflow[0].computeSSHKeySecretName
       - description: A URL of a container image that should be used by the test-operator
           for tests execution.

--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -290,6 +290,7 @@ func (r *AnsibleTestReconciler) PrepareAnsibleEnv(
 	envVars["POD_ANSIBLE_FILE_EXTRA_VARS"] = env.SetValue(instance.Spec.AnsibleVarFiles)
 	envVars["POD_ANSIBLE_INVENTORY"] = env.SetValue(instance.Spec.AnsibleInventory)
 	envVars["POD_ANSIBLE_GIT_REPO"] = env.SetValue(instance.Spec.AnsibleGitRepo)
+	envVars["POD_ANSIBLE_GIT_BRANCH"] = env.SetValue(instance.Spec.AnsibleGitBranch)
 	envVars["POD_ANSIBLE_PLAYBOOK"] = env.SetValue(instance.Spec.AnsiblePlaybookPath)
 	envVars["POD_INSTALL_COLLECTIONS"] = env.SetValue(instance.Spec.AnsibleCollections)
 


### PR DESCRIPTION
Allow selecting which branch checkout and run the ansible playbook

This allows the playbook to be be run from different branches, which
adds some flexibility:
* The playbook can live on different branches, allowing for versioning
  of the playbook/tests.
* The playbook can be tested in CI prior to merging

Depends-On: https://github.com/openstack-k8s-operators/tcib/pull/329