### PR TITLE
Fix typos across test-operator code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ docker-push: ## Push docker image with the manager.
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
 # - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
 # - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# - be able to push the image for your registry (i.e. if you do not pass a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
 # To properly provided solutions that supports more than one platform you should use this option.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pre-commit install --install-hooks
 2. Execute pre-commit checks
 
 ```bash
-pre-commit run --show-diff-on-failure --color=always --all-files --show-diff-on-failure --verbose
+pre-commit run --show-diff-on-failure --color=always --all-files --verbose
 ```
 
 ### Test It Out

--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -1285,7 +1285,7 @@ spec:
                   capabilities on top of capabilities that are usually needed by the test
                   pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
                   needed for certain test-operator functionalities to work properly (e.g.:
-                  extraRPMs in Tempest CR, or certain set of tobiko tests).
+                  extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
               resources:
                 default:
@@ -1513,7 +1513,7 @@ spec:
                         pods with allowedPrivilegedEscalation: true and the default capabilities on
                         top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
                         This parameter is deemed insecure but it is needed for certain test-operator
-                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
                         of tobiko tests).
                       type: boolean
                     resources:

--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -1303,7 +1303,7 @@ spec:
                   capabilities on top of capabilities that are usually needed by the test
                   pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
                   needed for certain test-operator functionalities to work properly (e.g.:
-                  extraRPMs in Tempest CR, or certain set of tobiko tests).
+                  extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
               projectName:
                 default: horizontest

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -1284,7 +1284,7 @@ spec:
                   capabilities on top of capabilities that are usually needed by the test
                   pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
                   needed for certain test-operator functionalities to work properly (e.g.:
-                  extraRPMs in Tempest CR, or certain set of tobiko tests).
+                  extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
               rerunFailedTests:
                 default: false
@@ -1375,7 +1375,7 @@ spec:
               tempestRun:
                 description: |-
                   TempestRunSpec - is used to configure execution of tempest. Please refer to
-                  Please refer to https://docs.openstack.org/tempest/latest/ for the further
+                  Please refer to https://docs.openstack.org/tempest/latest/ for further
                   explanation of the CLI parameters.
                 properties:
                   concurrency:
@@ -1554,7 +1554,7 @@ spec:
               tempestconfRun:
                 description: |-
                   TempestconfRunSpec - is used to configure execution of discover-tempest-config
-                  Please refer to https://docs.opendev.org/openinfra/python-tempestconf for the
+                  Please refer to https://docs.opendev.org/openinfra/python-tempestconf for
                   further explanation of the CLI parameters.
                 properties:
                   append:
@@ -1752,7 +1752,7 @@ spec:
                   Workflow - can be used to specify multiple executions of tempest with
                   a different configuration in a single CR. Accepts a list of dictionaries
                   where each member of the list accepts the same values as the Tempest CR
-                  does in the `spec`` section. Values specified using the workflow section have
+                  does in the `spec` section. Values specified using the workflow section have
                   a higher precedence than the values specified higher in the Tempest CR
                   hierarchy.
                 items:
@@ -1854,7 +1854,7 @@ spec:
                         pods with allowedPrivilegedEscalation: true and the default capabilities on
                         top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
                         This parameter is deemed insecure but it is needed for certain test-operator
-                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
                         of tobiko tests).
                       type: boolean
                     rerunFailedTests:
@@ -1941,8 +1941,8 @@ spec:
                       type: string
                     tempestRun:
                       description: |-
-                        TempestRunSpec - is used to configure execution of tempest. Please refer to
-                        Please refer to https://docs.openstack.org/tempest/latest/ for the further
+                        WorkflowTempestRunSpec - is used to configure execution of tempest.
+                        Please refer to https://docs.openstack.org/tempest/latest/ for further
                         explanation of the CLI parameters.
                       properties:
                         concurrency:
@@ -2088,7 +2088,7 @@ spec:
                           type: array
                         extraRPMs:
                           description: |-
-                            A list URLs that point to RPMs that should be downloaded and installed
+                            A list of URLs that point to RPMs that should be downloaded and installed
                             inside the tempest test pod.
                           items:
                             type: string
@@ -2116,8 +2116,8 @@ spec:
                       type: object
                     tempestconfRun:
                       description: |-
-                        TempestconfRunSpec - is used to configure execution of discover-tempest-config
-                        Please refer to https://docs.opendev.org/openinfra/python-tempestconf for the
+                        WorkflowTempestconfRunSpec - is used to configure execution of discover-tempest-config
+                        Please refer to https://docs.opendev.org/openinfra/python-tempestconf for
                         further explanation of the CLI parameters.
                       properties:
                         append:

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -1289,7 +1289,7 @@ spec:
                   capabilities on top of capabilities that are usually needed by the test
                   pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
                   needed for certain test-operator functionalities to work properly (e.g.:
-                  extraRPMs in Tempest CR, or certain set of tobiko tests).
+                  extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
               publicKey:
                 default: ""
@@ -1423,7 +1423,7 @@ spec:
                 description: Tobiko version
                 type: string
               workflow:
-                description: A parameter  that contains a workflow definition.
+                description: A parameter that contains a workflow definition.
                 items:
                   properties:
                     SELinuxLevel:
@@ -1496,7 +1496,7 @@ spec:
                       type: object
                     numProcesses:
                       description: Number of processes/workers used to run tobiko
-                        tests - value 0 results in automatic decission
+                        tests - value 0 results in automatic decision
                       type: integer
                     patch:
                       description: Optional patch to apply to the Tobiko repository
@@ -1526,7 +1526,7 @@ spec:
                         pods with allowedPrivilegedEscalation: true and the default capabilities on
                         top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
                         This parameter is deemed insecure but it is needed for certain test-operator
-                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
                         of tobiko tests).
                       type: boolean
                     publicKey:

--- a/api/v1beta1/ansibletest_types.go
+++ b/api/v1beta1/ansibletest_types.go
@@ -58,7 +58,7 @@ type AnsibleTestSpec struct {
 	// +kubebuilder:validation:Format=string
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// AnsibleGitBranch - git branch to check out in the cloned repo
-	AnsibleGitBranch string `json:"ansibleGitBranch,omitEmpty"`
+	AnsibleGitBranch string `json:"ansibleGitBranch,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
@@ -144,7 +144,7 @@ type AnsibleTestWorkflowSpec struct {
 	// +kubebuilder:validation:Format=string
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// AnsibleGitBranch - git branch to check out in the cloned repo
-	AnsibleGitBranch string `json:"ansibleGitBranch,omitEmpty"`
+	AnsibleGitBranch string `json:"ansibleGitBranch,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1beta1/ansibletest_webhook.go
+++ b/api/v1beta1/ansibletest_webhook.go
@@ -91,13 +91,13 @@ func (r *AnsibleTest) ValidateCreate() (admission.Warnings, error) {
 
 		if workflowStep.ExtraConfigmapsMounts != nil {
 			allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
-				"deprecated! Please use ExtraMounts parameter instead!")
+				" deprecated! Please use ExtraMounts parameter instead!")
 		}
 	}
 
 	if len(r.Spec.ExtraConfigmapsMounts) > 0 {
 		allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
-			"deprecated! Please use ExtraMounts parameter instead!")
+			" deprecated! Please use ExtraMounts parameter instead!")
 	}
 
 	if r.Spec.Privileged {

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -54,7 +54,7 @@ type CommonOptions struct {
 	// capabilities on top of capabilities that are usually needed by the test
 	// pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
 	// needed for certain test-operator functionalities to work properly (e.g.:
-	// extraRPMs in Tempest CR, or certain set of tobiko tests).
+	// extraRPMs in Tempest CR, or a certain set of tobiko tests).
 	Privileged bool `json:"privileged"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
@@ -145,7 +145,7 @@ type WorkflowCommonOptions struct {
 	// pods with allowedPrivilegedEscalation: true and the default capabilities on
 	// top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
 	// This parameter is deemed insecure but it is needed for certain test-operator
-	// functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+	// functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
 	// of tobiko tests).
 	Privileged *bool `json:"privileged,omitempty"`
 

--- a/api/v1beta1/common_webhook.go
+++ b/api/v1beta1/common_webhook.go
@@ -2,7 +2,7 @@ package v1beta1
 
 const (
 	// ErrPrivilegedModeRequired
-	ErrPrivilegedModeRequired = "%s.Spec.Privileged is requied in order to successfully " +
+	ErrPrivilegedModeRequired = "%s.Spec.Privileged is required in order to successfully " +
 		"execute tests with the provided configuration."
 
 	// ErrDebug

--- a/api/v1beta1/horizontest_webhook.go
+++ b/api/v1beta1/horizontest_webhook.go
@@ -65,7 +65,7 @@ func (r *HorizonTest) ValidateCreate() (admission.Warnings, error) {
 
 	if len(r.Spec.ExtraConfigmapsMounts) > 0 {
 		allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
-			"deprecated! Please use ExtraMounts parameter instead!")
+			" deprecated! Please use ExtraMounts parameter instead!")
 	}
 
 	if r.Spec.Privileged {

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -14,13 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-This file contains an extension of the Tempest CR. Ultimately it is a copy of
-tempest_types.go that removes all default values for each config options. This
-is necessary to be able to detect when the user explicitly sets a value in the
-`workflow` section.
-*/
-
 package v1beta1
 
 import (
@@ -151,7 +144,7 @@ type ExternalPluginType struct {
 }
 
 // TempestRunSpec - is used to configure execution of tempest. Please refer to
-// Please refer to https://docs.openstack.org/tempest/latest/ for the further
+// Please refer to https://docs.openstack.org/tempest/latest/ for further
 // explanation of the CLI parameters.
 type TempestRunSpec struct {
 	// +kubebuilder:validation:Optional
@@ -225,7 +218,7 @@ type TempestRunSpec struct {
 }
 
 // TempestconfRunSpec - is used to configure execution of discover-tempest-config
-// Please refer to https://docs.opendev.org/openinfra/python-tempestconf for the
+// Please refer to https://docs.opendev.org/openinfra/python-tempestconf for
 // further explanation of the CLI parameters.
 type TempestconfRunSpec struct {
 	// +kubebuilder:validation:Optional
@@ -483,7 +476,7 @@ type TempestSpec struct {
 	// Workflow - can be used to specify multiple executions of tempest with
 	// a different configuration in a single CR. Accepts a list of dictionaries
 	// where each member of the list accepts the same values as the Tempest CR
-	// does in the `spec`` section. Values specified using the workflow section have
+	// does in the `spec` section. Values specified using the workflow section have
 	// a higher precedence than the values specified higher in the Tempest CR
 	// hierarchy.
 	Workflow []WorkflowTempestSpec `json:"workflow,omitempty"`

--- a/api/v1beta1/tempest_types_workflow.go
+++ b/api/v1beta1/tempest_types_workflow.go
@@ -14,12 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+This file contains an extension of the Tempest CR. Ultimately it is a copy of
+tempest_types.go that removes all default values for each config options. This
+is necessary to be able to detect when the user explicitly sets a value in the
+`workflow` section.
+*/
+
 package v1beta1
 
 import corev1 "k8s.io/api/core/v1"
 
-// TempestRunSpec - is used to configure execution of tempest. Please refer to
-// Please refer to https://docs.openstack.org/tempest/latest/ for the further
+// WorkflowTempestRunSpec - is used to configure execution of tempest.
+// Please refer to https://docs.openstack.org/tempest/latest/ for further
 // explanation of the CLI parameters.
 type WorkflowTempestRunSpec struct {
 	// +kubebuilder:validation:Optional
@@ -75,7 +82,7 @@ type WorkflowTempestRunSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// A list URLs that point to RPMs that should be downloaded and installed
+	// A list of URLs that point to RPMs that should be downloaded and installed
 	// inside the tempest test pod.
 	ExtraRPMs *[]string `json:"extraRPMs,omitempty"`
 
@@ -86,8 +93,8 @@ type WorkflowTempestRunSpec struct {
 	ExtraImages *[]ExtraImagesType `json:"extraImages,omitempty"`
 }
 
-// TempestconfRunSpec - is used to configure execution of discover-tempest-config
-// Please refer to https://docs.opendev.org/openinfra/python-tempestconf for the
+// WorkflowTempestconfRunSpec - is used to configure execution of discover-tempest-config
+// Please refer to https://docs.opendev.org/openinfra/python-tempestconf for
 // further explanation of the CLI parameters.
 type WorkflowTempestconfRunSpec struct {
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/tempest_webhook.go
+++ b/api/v1beta1/tempest_webhook.go
@@ -132,13 +132,13 @@ func (r *Tempest) ValidateCreate() (admission.Warnings, error) {
 
 		if workflowStep.ExtraConfigmapsMounts != nil {
 			allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
-				"deprecated! Please use ExtraMounts parameter instead!")
+				" deprecated! Please use ExtraMounts parameter instead!")
 		}
 	}
 
 	if len(r.Spec.ExtraConfigmapsMounts) > 0 {
 		allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
-			"deprecated! Please use ExtraMounts parameter instead!")
+			" deprecated! Please use ExtraMounts parameter instead!")
 	}
 
 	if r.Spec.Privileged {

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -128,7 +128,7 @@ type TobikoSpec struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
-	// A parameter  that contains a workflow definition.
+	// A parameter that contains a workflow definition.
 	Workflow []TobikoWorkflowSpec `json:"workflow,omitempty"`
 }
 
@@ -156,7 +156,7 @@ type TobikoWorkflowSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// Number of processes/workers used to run tobiko tests - value 0 results in automatic decission
+	// Number of processes/workers used to run tobiko tests - value 0 results in automatic decision
 	NumProcesses *uint8 `json:"numProcesses,omitempty"`
 
 	// +kubebuilder:validation:Optional
@@ -175,7 +175,7 @@ type TobikoWorkflowSpec struct {
 	// Optional patch to apply to the Tobiko repository for this step.
 	Patch *PatchType `json:"patch,omitempty"`
 
-        // +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// tobiko.conf
 	Config string `json:"config,omitempty"`

--- a/api/v1beta1/tobiko_webhook.go
+++ b/api/v1beta1/tobiko_webhook.go
@@ -99,13 +99,13 @@ func (r *Tobiko) ValidateCreate() (admission.Warnings, error) {
 
 		if workflowStep.ExtraConfigmapsMounts != nil {
 			allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
-				"deprecated! Please use ExtraMounts parameter instead!")
+				" deprecated! Please use ExtraMounts parameter instead!")
 		}
 	}
 
 	if len(r.Spec.ExtraConfigmapsMounts) > 0 {
 		allWarnings = append(allWarnings, "The ExtraConfigmapsMounts parameter will be" +
-			"deprecated! Please use ExtraMounts parameter instead!")
+			" deprecated! Please use ExtraMounts parameter instead!")
 	}
 
 	if r.Spec.Privileged {

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -1285,7 +1285,7 @@ spec:
                   capabilities on top of capabilities that are usually needed by the test
                   pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
                   needed for certain test-operator functionalities to work properly (e.g.:
-                  extraRPMs in Tempest CR, or certain set of tobiko tests).
+                  extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
               resources:
                 default:
@@ -1513,7 +1513,7 @@ spec:
                         pods with allowedPrivilegedEscalation: true and the default capabilities on
                         top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
                         This parameter is deemed insecure but it is needed for certain test-operator
-                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
                         of tobiko tests).
                       type: boolean
                     resources:

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -1303,7 +1303,7 @@ spec:
                   capabilities on top of capabilities that are usually needed by the test
                   pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
                   needed for certain test-operator functionalities to work properly (e.g.:
-                  extraRPMs in Tempest CR, or certain set of tobiko tests).
+                  extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
               projectName:
                 default: horizontest

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -1284,7 +1284,7 @@ spec:
                   capabilities on top of capabilities that are usually needed by the test
                   pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
                   needed for certain test-operator functionalities to work properly (e.g.:
-                  extraRPMs in Tempest CR, or certain set of tobiko tests).
+                  extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
               rerunFailedTests:
                 default: false
@@ -1375,7 +1375,7 @@ spec:
               tempestRun:
                 description: |-
                   TempestRunSpec - is used to configure execution of tempest. Please refer to
-                  Please refer to https://docs.openstack.org/tempest/latest/ for the further
+                  Please refer to https://docs.openstack.org/tempest/latest/ for further
                   explanation of the CLI parameters.
                 properties:
                   concurrency:
@@ -1554,7 +1554,7 @@ spec:
               tempestconfRun:
                 description: |-
                   TempestconfRunSpec - is used to configure execution of discover-tempest-config
-                  Please refer to https://docs.opendev.org/openinfra/python-tempestconf for the
+                  Please refer to https://docs.opendev.org/openinfra/python-tempestconf for
                   further explanation of the CLI parameters.
                 properties:
                   append:
@@ -1752,7 +1752,7 @@ spec:
                   Workflow - can be used to specify multiple executions of tempest with
                   a different configuration in a single CR. Accepts a list of dictionaries
                   where each member of the list accepts the same values as the Tempest CR
-                  does in the `spec`` section. Values specified using the workflow section have
+                  does in the `spec` section. Values specified using the workflow section have
                   a higher precedence than the values specified higher in the Tempest CR
                   hierarchy.
                 items:
@@ -1854,7 +1854,7 @@ spec:
                         pods with allowedPrivilegedEscalation: true and the default capabilities on
                         top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
                         This parameter is deemed insecure but it is needed for certain test-operator
-                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
                         of tobiko tests).
                       type: boolean
                     rerunFailedTests:
@@ -1941,8 +1941,8 @@ spec:
                       type: string
                     tempestRun:
                       description: |-
-                        TempestRunSpec - is used to configure execution of tempest. Please refer to
-                        Please refer to https://docs.openstack.org/tempest/latest/ for the further
+                        WorkflowTempestRunSpec - is used to configure execution of tempest.
+                        Please refer to https://docs.openstack.org/tempest/latest/ for further
                         explanation of the CLI parameters.
                       properties:
                         concurrency:
@@ -2088,7 +2088,7 @@ spec:
                           type: array
                         extraRPMs:
                           description: |-
-                            A list URLs that point to RPMs that should be downloaded and installed
+                            A list of URLs that point to RPMs that should be downloaded and installed
                             inside the tempest test pod.
                           items:
                             type: string
@@ -2116,8 +2116,8 @@ spec:
                       type: object
                     tempestconfRun:
                       description: |-
-                        TempestconfRunSpec - is used to configure execution of discover-tempest-config
-                        Please refer to https://docs.opendev.org/openinfra/python-tempestconf for the
+                        WorkflowTempestconfRunSpec - is used to configure execution of discover-tempest-config
+                        Please refer to https://docs.opendev.org/openinfra/python-tempestconf for
                         further explanation of the CLI parameters.
                       properties:
                         append:

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -1289,7 +1289,7 @@ spec:
                   capabilities on top of capabilities that are usually needed by the test
                   pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is
                   needed for certain test-operator functionalities to work properly (e.g.:
-                  extraRPMs in Tempest CR, or certain set of tobiko tests).
+                  extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
               publicKey:
                 default: ""
@@ -1423,7 +1423,7 @@ spec:
                 description: Tobiko version
                 type: string
               workflow:
-                description: A parameter  that contains a workflow definition.
+                description: A parameter that contains a workflow definition.
                 items:
                   properties:
                     SELinuxLevel:
@@ -1496,7 +1496,7 @@ spec:
                       type: object
                     numProcesses:
                       description: Number of processes/workers used to run tobiko
-                        tests - value 0 results in automatic decission
+                        tests - value 0 results in automatic decision
                       type: integer
                     patch:
                       description: Optional patch to apply to the Tobiko repository
@@ -1526,7 +1526,7 @@ spec:
                         pods with allowedPrivilegedEscalation: true and the default capabilities on
                         top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
                         This parameter is deemed insecure but it is needed for certain test-operator
-                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+                        functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
                         of tobiko tests).
                       type: boolean
                     publicKey:

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -108,7 +108,7 @@ spec:
           default capabilities on top of capabilities that are usually needed by the
           test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it
           is needed for certain test-operator functionalities to work properly (e.g.:
-          extraRPMs in Tempest CR, or certain set of tobiko tests).'
+          extraRPMs in Tempest CR, or a certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
       - description: StorageClass used to create any test-operator related PVCs.
@@ -200,7 +200,7 @@ spec:
           capabilities on top of capabilities that are usually needed by the test
           pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
           for certain test-operator functionalities to work properly (e.g.: extraRPMs
-          in Tempest CR, or certain set of tobiko tests).'
+          in Tempest CR, or a certain set of tobiko tests).'
         displayName: Privileged
         path: workflow[0].privileged
       - description: Name of a workflow step. The step name will be used for example
@@ -321,7 +321,7 @@ spec:
           default capabilities on top of capabilities that are usually needed by the
           test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it
           is needed for certain test-operator functionalities to work properly (e.g.:
-          extraRPMs in Tempest CR, or certain set of tobiko tests).'
+          extraRPMs in Tempest CR, or a certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
       - description: ProjectName is the name of the OpenStack project for Horizon
@@ -433,7 +433,7 @@ spec:
           default capabilities on top of capabilities that are usually needed by the
           test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it
           is needed for certain test-operator functionalities to work properly (e.g.:
-          extraRPMs in Tempest CR, or certain set of tobiko tests).'
+          extraRPMs in Tempest CR, or a certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
       - description: Activate tempest re-run feature. When activated, tempest will
@@ -646,7 +646,7 @@ spec:
       - description: Workflow - can be used to specify multiple executions of tempest
           with a different configuration in a single CR. Accepts a list of dictionaries
           where each member of the list accepts the same values as the Tempest CR
-          does in the `spec`` section. Values specified using the workflow section
+          does in the `spec` section. Values specified using the workflow section
           have a higher precedence than the values specified higher in the Tempest
           CR hierarchy.
         displayName: Workflow
@@ -713,7 +713,7 @@ spec:
           capabilities on top of capabilities that are usually needed by the test
           pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
           for certain test-operator functionalities to work properly (e.g.: extraRPMs
-          in Tempest CR, or certain set of tobiko tests).'
+          in Tempest CR, or a certain set of tobiko tests).'
         displayName: Privileged
         path: workflow[0].privileged
       - description: Activate tempest re-run feature. When activated, tempest will
@@ -803,7 +803,7 @@ spec:
       - description: Cloud that should be used for authentication
         displayName: Os Cloud
         path: workflow[0].tempestRun.extraImages.osCloud
-      - description: A list URLs that point to RPMs that should be downloaded and
+      - description: A list of URLs that point to RPMs that should be downloaded and
           installed inside the tempest test pod.
         displayName: Extra RPMs
         path: workflow[0].tempestRun.extraRPMs
@@ -1010,7 +1010,7 @@ spec:
           default capabilities on top of capabilities that are usually needed by the
           test pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it
           is needed for certain test-operator functionalities to work properly (e.g.:
-          extraRPMs in Tempest CR, or certain set of tobiko tests).'
+          extraRPMs in Tempest CR, or a certain set of tobiko tests).'
         displayName: Privileged
         path: privileged
       - description: Public Key
@@ -1033,7 +1033,7 @@ spec:
       - description: Tobiko version
         displayName: Version
         path: version
-      - description: A parameter  that contains a workflow definition.
+      - description: A parameter that contains a workflow definition.
         displayName: Workflow
         path: workflow
         x-descriptors:
@@ -1083,7 +1083,7 @@ spec:
         displayName: Node Selector
         path: workflow[0].nodeSelector
       - description: Number of processes/workers used to run tobiko tests - value
-          0 results in automatic decission
+          0 results in automatic decision
         displayName: Num Processes
         path: workflow[0].numProcesses
       - description: Optional patch to apply to the Tobiko repository for this step.
@@ -1101,7 +1101,7 @@ spec:
           capabilities on top of capabilities that are usually needed by the test
           pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed
           for certain test-operator functionalities to work properly (e.g.: extraRPMs
-          in Tempest CR, or certain set of tobiko tests).'
+          in Tempest CR, or a certain set of tobiko tests).'
         displayName: Privileged
         path: workflow[0].privileged
       - description: Public Key

--- a/config/samples/test_v1beta1_ansibletest.yaml
+++ b/config/samples/test_v1beta1_ansibletest.yaml
@@ -10,8 +10,8 @@ spec:
       subPath: this.conf
       mountPath: /var/conf
   debug: true
-  storageClass: "local-storage"
-  workloadSSHKeySecretName: 'open-ssh-keys'
+  storageClass: local-storage
+  workloadSSHKeySecretName: open-ssh-keys
   ansiblePlaybookPath: playbooks/my_playbook.yaml
   ansibleGitRepo: https://github.com/myansible/project
   # containerImage:
@@ -29,7 +29,7 @@ spec:
   # pods with allowedPrivilegedEscalation: true and the default capabilities on
   # top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
   # This parameter is deemed insecure but it is needed for certain test-operator
-  # functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+  # functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
   # of tobiko tests).
   #
   # privileged: false
@@ -55,7 +55,7 @@ spec:
   #     cpu: 2000m
   #     memory: 2Gi
   workflow:
-    - stepName: beststep
+    - stepName: best-step
       ansibleExtraVars: ' -e manual_run=false '
-    - stepName: laststep
+    - stepName: last-step
       ansibleExtraVars: ' -e manual_run=false '

--- a/config/samples/test_v1beta1_horizontest.yaml
+++ b/config/samples/test_v1beta1_horizontest.yaml
@@ -69,7 +69,7 @@ spec:
   # pods with allowedPrivilegedEscalation: true and the default capabilities on
   # top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
   # This parameter is deemed insecure but it is needed for certain test-operator
-  # functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+  # functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
   # of tobiko tests).
   #
   # privileged: false

--- a/config/samples/test_v1beta1_tempest.yaml
+++ b/config/samples/test_v1beta1_tempest.yaml
@@ -35,7 +35,7 @@ spec:
   # default capabilities on top of capabilities that are usually needed by the test
   # pods (NET_ADMIN, NET_RAW). This parameter is deemed insecure but it is needed for
   # certain test-operator functionalities to work properly (e.g.: extraRPMs in Tempest CR,
-  # or certain set tobiko tests).
+  # or a certain set of tobiko tests).
   #
   # privileged: false
   #
@@ -86,16 +86,16 @@ spec:
     # extraImages:
     #   - URL: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
     #     name: cirros-0.6.2-test-operator
-    #       flavor:
-    #         name: cirros-0.6.2-test-operator-flavor
-    #         RAM: 512
-    #         disk: 20
-    #         vcpus: 1
+    #     flavor:
+    #       name: cirros-0.6.2-test-operator-flavor
+    #       RAM: 512
+    #       disk: 20
+    #       vcpus: 1
 
     # extraRPMs:
     # ----------
     # A list of URLs that point to RPMs that should be installed before
-    # the execution of tempest. WARNING! This parameter has no efect when used
+    # the execution of tempest. WARNING! This parameter has no effect when used
     # in combination with externalPlugin parameter.
     # extraRPMs:
     #   - https://cbs.centos.org/kojifiles/packages/python-sshtunnel/0.4.0/12.el9s/noarch/python3-sshtunnel-0.4.0-12.el9s.noarch.rpm
@@ -124,7 +124,7 @@ spec:
     # as /etc/test_operator/deployer_input.yaml
     # deployerInput: |
     #   [section]
-    #   value1 = exmaple_value2
+    #   value1 = example_value2
     #   value2 = example_value2
 
     # The following text will be mounted to the tempest pod
@@ -167,11 +167,11 @@ spec:
   # tempestconfRun sections.
   #
   # workflow:
-  #   - stepName: firstStep
+  #   - stepName: first-step
   #     tempestRun:
   #       includeList: |
   #         tempest.api.*
-  #   - stepName: secondStep
+  #   - stepName: second-step
   #     tempestRun:
   #       includeList: |
   #         neutron_tempest_plugin.*

--- a/config/samples/test_v1beta1_tobiko.yaml
+++ b/config/samples/test_v1beta1_tobiko.yaml
@@ -14,7 +14,7 @@ spec:
   # pods with allowedPrivilegedEscalation: true and the default capabilities on
   # top of capabilities that are usually needed by the test pods (NET_ADMIN, NET_RAW).
   # This parameter is deemed insecure but it is needed for certain test-operator
-  # functionalities to work properly (e.g.: extraRPMs in Tempest CR, or certain set
+  # functionalities to work properly (e.g.: extraRPMs in Tempest CR, or a certain set
   # of tobiko tests).
   #
   # privileged: false

--- a/controllers/ansibletest_controller.go
+++ b/controllers/ansibletest_controller.go
@@ -87,7 +87,7 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		instance.Status.Conditions = condition.Conditions{}
 	}
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 
@@ -227,7 +227,7 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	ctrlResult, err = r.CreatePod(ctx, *helper, podDef)
 	if err != nil {
-		// Creation of the ansibleTests pod was not successfull.
+		// Creation of the ansibleTests pod was not successful.
 		// Release the lock and allow other controllers to spawn
 		// a pod.
 		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -31,8 +31,8 @@ import (
 
 const (
 	podNameStepInfix         = "-s"
-	envVarsConfigMapinfix    = "-env-vars-s"
-	customDataConfigMapinfix = "-custom-data-s"
+	envVarsConfigMapInfix    = "-env-vars-s"
+	customDataConfigMapInfix = "-custom-data-s"
 	workflowStepNumInvalid   = -1
 	workflowStepNameInvalid  = "no-name"
 	workflowStepLabel        = "workflowStep"
@@ -40,7 +40,7 @@ const (
 	operatorNameLabel        = "operator"
 
 	testOperatorLockName       = "test-operator-lock"
-	testOperatorLockOnwerField = "owner"
+	testOperatorLockOwnerField = "owner"
 )
 
 const (
@@ -180,7 +180,7 @@ func (r *Reconciler) NextAction(
 			return Failure, workflowStepIdx, err
 		}
 
-		// If the last pod is not in Failed or Succeded state -> Wait
+		// If the last pod is not in Failed or Succeeded state -> Wait
 		lastPodFinished := lastPod.Status.Phase == corev1.PodFailed || lastPod.Status.Phase == corev1.PodSucceeded
 		if !lastPodFinished {
 			return Wait, workflowStepIdx, nil
@@ -193,7 +193,7 @@ func (r *Reconciler) NextAction(
 			return CreateNextPod, workflowStepIdx, nil
 		}
 
-		// Otherwise if the pod is in Failed or Succeded stated and it IS the
+		// Otherwise if the pod is in Failed or Succeeded state and it IS the
 		// last pod -> EndTesting
 		if lastPodFinished && isLastPodIndex(workflowStepIdx, workflowLength) {
 			return EndTesting, workflowStepIdx, nil
@@ -258,7 +258,7 @@ func GetEnvVarsConfigMapName(instance interface{}, workflowStepNum int) string {
 	if _, ok := instance.(*v1beta1.Tobiko); ok {
 		return "not-implemented"
 	} else if typedInstance, ok := instance.(*v1beta1.Tempest); ok {
-		return typedInstance.Name + envVarsConfigMapinfix + strconv.Itoa(workflowStepNum)
+		return typedInstance.Name + envVarsConfigMapInfix + strconv.Itoa(workflowStepNum)
 	}
 
 	return "not-implemented"
@@ -269,7 +269,7 @@ func GetCustomDataConfigMapName(instance interface{}, workflowStepNum int) strin
 	if _, ok := instance.(*v1beta1.Tobiko); ok {
 		return "not-implemented"
 	} else if typedInstance, ok := instance.(*v1beta1.Tempest); ok {
-		return typedInstance.Name + customDataConfigMapinfix + strconv.Itoa(workflowStepNum)
+		return typedInstance.Name + customDataConfigMapInfix + strconv.Itoa(workflowStepNum)
 	}
 
 	return "not-implemented"
@@ -537,8 +537,8 @@ func (r *Reconciler) GetLockInfo(ctx context.Context, instance client.Object) (*
 		return cm, err
 	}
 
-	if _, ok := cm.Data[testOperatorLockOnwerField]; !ok {
-		return cm, fmt.Errorf("%w: %s field is missing in the %s config map", ErrLockFieldMissing, testOperatorLockOnwerField, testOperatorLockName)
+	if _, ok := cm.Data[testOperatorLockOwnerField]; !ok {
+		return cm, fmt.Errorf("%w: %s field is missing in the %s config map", ErrLockFieldMissing, testOperatorLockOwnerField, testOperatorLockName)
 	}
 
 	return cm, err
@@ -561,7 +561,7 @@ func (r *Reconciler) AcquireLock(
 	cm, err := r.GetLockInfo(ctx, instance)
 	if err != nil && k8s_errors.IsNotFound(err) {
 		cm := map[string]string{
-			testOperatorLockOnwerField: instanceGUID,
+			testOperatorLockOwnerField: instanceGUID,
 		}
 
 		cms := []util.Template{
@@ -576,7 +576,7 @@ func (r *Reconciler) AcquireLock(
 		return err == nil, err
 	}
 
-	if cm.Data[testOperatorLockOnwerField] == instanceGUID {
+	if cm.Data[testOperatorLockOwnerField] == instanceGUID {
 		return true, nil
 	}
 
@@ -595,7 +595,7 @@ func (r *Reconciler) ReleaseLock(ctx context.Context, instance client.Object) (b
 	}
 
 	// Lock can be only released by the instance that created it
-	if cm.Data[testOperatorLockOnwerField] != string(instance.GetUID()) {
+	if cm.Data[testOperatorLockOwnerField] != string(instance.GetUID()) {
 		return false, nil
 	}
 
@@ -604,7 +604,7 @@ func (r *Reconciler) ReleaseLock(ctx context.Context, instance client.Object) (b
 		return false, nil
 	}
 
-	// Check whether the lock was successfully deleted deleted
+	// Check whether the lock was successfully deleted
 	maxRetries := 10
 	lockDeletionSleepPeriod := 10
 	for i := 0; i < maxRetries; i++ {

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -82,7 +82,7 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		instance.Status.Conditions = condition.Conditions{}
 	}
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -92,7 +92,7 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		instance.Status.Conditions = condition.Conditions{}
 	}
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 
@@ -308,7 +308,7 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	ctrlResult, err = r.CreatePod(ctx, *helper, podDef)
 	if err != nil {
-		// Creation of the tempest pod was not successfull.
+		// Creation of the tempest pod was not successful.
 		// Release the lock and allow other controllers to spawn
 		// a pod.
 		if lockReleased, lockErr := r.ReleaseLock(ctx, instance); lockReleased {
@@ -558,7 +558,7 @@ func (r *TempestReconciler) setTempestconfConfigVars(
 }
 
 // Create ConfigMaps:
-//   - %-env-vars contians all the environment variables that are needed for
+//   - %-env-vars contains all the environment variables that are needed for
 //     execution of the tempest container
 //   - %-config contains all the files that are needed for the execution of
 //     the tempest container

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -89,7 +89,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		instance.Status.Conditions = condition.Conditions{}
 	}
 
-	// Save a copy of the condtions so that we can restore the LastTransitionTime
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
 	// when a condition's state doesn't change.
 	savedConditions := instance.Status.Conditions.DeepCopy()
 
@@ -172,7 +172,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	case CreateNextPod:
 		// Confirm that we still hold the lock. This needs to be checked in order
 		// to prevent situation when somebody / something deleted the lock and it
-		// got claimedy by another instance.
+		// got claimed by another instance.
 		lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
 		if !lockAcquired {
 			Log.Error(err, ErrConfirmLockOwnership, testOperatorLockName)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-# This patterns also effect to html_static_path and html_extra_path
+# These patterns also affect html_static_path and html_extra_path
 exclude_patterns = []
 
 # This is needed so that we do not treat the following warning in a job

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -264,7 +264,7 @@ associated with the test run.
 
 .. note::
    Please keep in mind that all resources created by the test operator are bound
-   to the CR. Once you remove the CR (e.g.::code:`tempest/tempest-tests`), then
+   to the CR. Once you remove the CR (e.g. :code:`tempest/tempest-tests`), then
    you also remove the PV containing the logs.
 
 If you want to retrieve the logs from the pv, you can follow these steps:

--- a/docs/source/images.rst
+++ b/docs/source/images.rst
@@ -61,4 +61,4 @@ HorizonTest Image
 
   An image that installs horizon directly from the source code downloaded from
   `x/horizon <https://opendev.org/openstack/horizon.git>`_ repository and prepares
-  the enviroment for selenium tests to run
+  the environment for selenium tests to run

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func main() {
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
-		// speeds up voluntary leader transitions as the new leader don't have to wait
+		// speeds up voluntary leader transitions as the new leader doesn't have to wait
 		// LeaseDuration time first.
 		//
 		// In the default scaffold provided, the program ends immediately after

--- a/pkg/tobiko/pod.go
+++ b/pkg/tobiko/pod.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Pod - prepare pod to run Tempest tests
+// Pod - prepare pod to run Tobiko tests
 func Pod(
 	instance *testv1beta1.Tobiko,
 	labels map[string]string,

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	// TestOperatorCloudsConfigMapName is name of the ConfigMap which contains
+	// TestOperatorCloudsConfigMapName is the name of the ConfigMap which contains
 	// modified clouds.yaml obtained from openstack-config ConfigMap. The modified
 	// CM is needed by some test frameworks (e.g., HorizonTest and Tobiko)
 	TestOperatorCloudsConfigMapName = "test-operator-clouds-config"
@@ -46,7 +46,7 @@ func GetSecurityContext(
 
 	if privileged {
 		// Sometimes we require the test pods run sudo to be able to install
-		// additional packages or run commands with elevated priveleges (e.g.,
+		// additional packages or run commands with elevated privileges (e.g.,
 		// tcpdump in case of Tobiko)
 		securityContext.RunAsNonRoot = &falseVar
 


### PR DESCRIPTION
I have been marking typos and copy-paste errors when I was working on test-operator. Now it is time to fix them all in one patch. Additionally, grammatical typos found by LLM are also being fixed.