### PR TITLE
Introduce common controller

### DIFF
--- a/api/v1beta1/ansibletest_types.go
+++ b/api/v1beta1/ansibletest_types.go
@@ -220,3 +220,18 @@ func (instance AnsibleTest) RbacNamespace() string {
 func (instance AnsibleTest) RbacResourceName() string {
 	return instance.Name
 }
+
+// GetConditions - return the conditions from the status
+func (instance *AnsibleTest) GetConditions() *condition.Conditions {
+	return &instance.Status.Conditions
+}
+
+// GetStorageClass - return the storage class name
+func (instance *AnsibleTest) GetStorageClass() string {
+	return instance.Spec.StorageClass
+}
+
+// SetObservedGeneration - set the observed generation to the current generation
+func (instance *AnsibleTest) SetObservedGeneration() {
+	instance.Status.ObservedGeneration = instance.Generation
+}

--- a/api/v1beta1/horizontest_types.go
+++ b/api/v1beta1/horizontest_types.go
@@ -191,3 +191,18 @@ func (instance HorizonTest) RbacNamespace() string {
 func (instance HorizonTest) RbacResourceName() string {
 	return instance.Name
 }
+
+// GetConditions - return the conditions from the status
+func (instance *HorizonTest) GetConditions() *condition.Conditions {
+	return &instance.Status.Conditions
+}
+
+// GetStorageClass - return the storage class name
+func (instance *HorizonTest) GetStorageClass() string {
+	return instance.Spec.StorageClass
+}
+
+// SetObservedGeneration - set the observed generation to the current generation
+func (instance *HorizonTest) SetObservedGeneration() {
+	instance.Status.ObservedGeneration = instance.Generation
+}

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -522,3 +522,18 @@ func (instance Tempest) RbacNamespace() string {
 func (instance Tempest) RbacResourceName() string {
 	return instance.Name
 }
+
+// GetConditions - return the conditions from the status
+func (instance *Tempest) GetConditions() *condition.Conditions {
+	return &instance.Status.Conditions
+}
+
+// GetStorageClass - return the storage class name
+func (instance *Tempest) GetStorageClass() string {
+	return instance.Spec.StorageClass
+}
+
+// SetObservedGeneration - set the observed generation to the current generation
+func (instance *Tempest) SetObservedGeneration() {
+	instance.Status.ObservedGeneration = instance.Generation
+}

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -246,3 +246,18 @@ func (instance Tobiko) RbacNamespace() string {
 func (instance Tobiko) RbacResourceName() string {
 	return instance.Name
 }
+
+// GetConditions - return the conditions from the status
+func (instance *Tobiko) GetConditions() *condition.Conditions {
+	return &instance.Status.Conditions
+}
+
+// GetStorageClass - return the storage class name
+func (instance *Tobiko) GetStorageClass() string {
+	return instance.Spec.StorageClass
+}
+
+// SetObservedGeneration - set the observed generation to the current generation
+func (instance *Tobiko) SetObservedGeneration() {
+	instance.Status.ObservedGeneration = instance.Generation
+}

--- a/internal/controller/ansibletest_controller.go
+++ b/internal/controller/ansibletest_controller.go
@@ -19,18 +19,13 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"strconv"
 
 	"github.com/go-logr/logr"
-	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	testv1beta1 "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/test-operator/internal/ansibletest"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -56,222 +51,76 @@ func (r *AnsibleTestReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
 
 // Reconcile - AnsibleTest
-func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	Log := r.GetLogger(ctx)
-
-	// Fetch the ansible instance
+func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	instance := &testv1beta1.AnsibleTest{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+
+	config := TestResourceConfig[*testv1beta1.AnsibleTest]{
+		ServiceName:             ansibletest.ServiceName,
+		NeedsNetworkAttachments: false,
+		NeedsConfigMaps:         false,
+		NeedsFinalizer:          false,
+		SupportsWorkflow:        true,
+
+		BuildPod: func(ctx context.Context, instance *testv1beta1.AnsibleTest, labels, annotations map[string]string, workflowStepIndex int, pvcIndex int) (*corev1.Pod, error) {
+			return r.buildAnsibleTestPod(ctx, instance, labels, annotations, workflowStepIndex, pvcIndex)
+		},
+
+		GetInitialConditions: func() []*condition.Condition {
+			return []*condition.Condition{
+				condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
+				condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+				condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+			}
+		},
+
+		ValidateInputs: func(ctx context.Context, instance *testv1beta1.AnsibleTest) error {
+			return r.ValidateOpenstackInputs(ctx, instance, instance.Spec.OpenStackConfigMap, instance.Spec.OpenStackConfigSecret)
+		},
+
+		GetSpec: func(instance *testv1beta1.AnsibleTest) interface{} {
+			return &instance.Spec
+		},
+
+		GetWorkflowStep: func(instance *testv1beta1.AnsibleTest, step int) interface{} {
+			return instance.Spec.Workflow[step]
+		},
+
+		GetWorkflowLength: func(instance *testv1beta1.AnsibleTest) int {
+			return len(instance.Spec.Workflow)
+		},
 	}
 
-	// Create a helper
-	helper, err := helper.NewHelper(
-		instance,
-		r.Client,
-		r.Kclient,
-		r.Scheme,
-		r.Log,
-	)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	return CommonReconcile(ctx, &r.Reconciler, req, instance, config, r.GetLogger(ctx))
+}
 
-	// initialize status
-	isNewInstance := instance.Status.Conditions == nil
-	if isNewInstance {
-		instance.Status.Conditions = condition.Conditions{}
-	}
-
-	// Save a copy of the conditions so that we can restore the LastTransitionTime
-	// when a condition's state doesn't change.
-	savedConditions := instance.Status.Conditions.DeepCopy()
-
-	// Always patch the instance status when exiting this function so we
-	// can persist any changes.
-	defer func() {
-		// Don't update the status, if reconciler Panics
-		if r := recover(); r != nil {
-			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
-			panic(r)
-		}
-		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
-		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
-			instance.Status.Conditions.Set(
-				instance.Status.Conditions.Mirror(condition.ReadyCondition))
-		}
-		err := helper.PatchInstance(ctx, instance)
-		if err != nil {
-			_err = err
-			return
-		}
-	}()
-
-	if isNewInstance {
-		// Initialize conditions used later as Status=Unknown
-		cl := condition.CreateList(
-			condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
-			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
-		)
-		instance.Status.Conditions.Init(&cl)
-
-		// Register overall status immediately to have an early feedback
-		// e.g. in the cli
-		return ctrl.Result{}, nil
-	}
-	instance.Status.ObservedGeneration = instance.Generation
-
-	workflowLength := len(instance.Spec.Workflow)
-	nextAction, workflowStepIndex, err := r.NextAction(ctx, instance, workflowLength)
-	if workflowStepIndex < workflowLength {
-		MergeSections(&instance.Spec, instance.Spec.Workflow[workflowStepIndex])
-	}
-
-	switch nextAction {
-	case Failure:
-		return ctrl.Result{}, err
-
-	case Wait:
-		Log.Info(InfoWaitingOnPod)
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, nil
-
-	case EndTesting:
-		// All pods created by the instance were completed. Release the lock
-		// so that other instances can spawn their pods.
-		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
-			Log.Info(fmt.Sprintf(InfoCanNotReleaseLock, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		instance.Status.Conditions.MarkTrue(
-			condition.DeploymentReadyCondition,
-			condition.DeploymentReadyMessage)
-
-		if instance.Status.Conditions.AllSubConditionIsTrue() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
-		}
-
-		Log.Info(InfoTestingCompleted)
-		return ctrl.Result{}, nil
-
-	case CreateFirstPod:
-		lockAcquired, err := r.AcquireLock(ctx, instance, helper, false)
-		if !lockAcquired {
-			Log.Info(fmt.Sprintf(InfoCanNotAcquireLock, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		Log.Info(fmt.Sprintf(InfoCreatingFirstPod, workflowStepIndex))
-
-	case CreateNextPod:
-		// Confirm that we still hold the lock. This is useful to check if for
-		// example somebody / something deleted the lock and it got claimed by
-		// another instance. This is considered to be an error state.
-		lockAcquired, err := r.AcquireLock(ctx, instance, helper, false)
-		if !lockAcquired {
-			Log.Error(err, fmt.Sprintf(ErrConfirmLockOwnership, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		Log.Info(fmt.Sprintf(InfoCreatingNextPod, workflowStepIndex))
-
-	default:
-		return ctrl.Result{}, ErrReceivedUnexpectedAction
-	}
-
-	serviceLabels := map[string]string{
-		common.AppSelector: ansibletest.ServiceName,
-		workflowStepLabel:  strconv.Itoa(workflowStepIndex),
-		instanceNameLabel:  instance.Name,
-		operatorNameLabel:  "test-operator",
-	}
-
-	err = r.ValidateOpenstackInputs(ctx, instance, instance.Spec.OpenStackConfigMap, instance.Spec.OpenStackConfigSecret)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityError,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-	}
-	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
-
-	// Create PersistentVolumeClaim
-	ctrlResult, err := r.EnsureLogsPVCExists(
-		ctx,
-		instance,
-		helper,
-		serviceLabels,
-		instance.Spec.StorageClass,
-		0,
-	)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-	// Create PersistentVolumeClaim - end
-
-	// Create a new pod
+func (r *AnsibleTestReconciler) buildAnsibleTestPod(
+	ctx context.Context,
+	instance *testv1beta1.AnsibleTest,
+	labels, _ map[string]string,
+	workflowStepIndex int,
+	pvcIndex int,
+) (*corev1.Pod, error) {
 	mountCerts := r.CheckSecretExists(ctx, instance, "combined-ca-bundle")
-	podName := r.GetPodName(instance, workflowStepIndex)
 	envVars := r.PrepareAnsibleEnv(instance)
-	logsPVCName := r.GetPVCLogsName(instance, 0)
+
+	podName := r.GetPodName(instance, workflowStepIndex)
+	logsPVCName := r.GetPVCLogsName(instance, pvcIndex)
+
 	containerImage, err := r.GetContainerImage(ctx, instance)
 	if err != nil {
-		return ctrl.Result{}, err
+		return nil, err
 	}
 
-	podDef := ansibletest.Pod(
+	return ansibletest.Pod(
 		instance,
-		serviceLabels,
+		labels,
 		podName,
 		logsPVCName,
 		mountCerts,
 		envVars,
 		workflowStepIndex,
 		containerImage,
-	)
-
-	ctrlResult, err = r.CreatePod(ctx, *helper, podDef)
-	if err != nil {
-		// Creation of the ansibleTests pod was not successful.
-		// Release the lock and allow other controllers to spawn
-		// a pod.
-		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
-			return ctrl.Result{}, err
-		}
-
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.DeploymentReadyErrorMessage,
-			err.Error()))
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.DeploymentReadyRunningMessage))
-		return ctrlResult, nil
-	}
-	// Create a new pod - end
-
-	if instance.Status.Conditions.AllSubConditionIsTrue() {
-		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
-	}
-
-	Log.Info("Reconciled Service successfully")
-	return ctrl.Result{}, nil
+	), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/common_controller.go
+++ b/internal/controller/common_controller.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	"github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	corev1 "k8s.io/api/core/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// TestResource defines the interface that all test-operator Custom Resources must implement
+type TestResource interface {
+	client.Object
+	GetConditions() *condition.Conditions
+	GetStorageClass() string
+	SetObservedGeneration()
+}
+
+// TestResourceConfig defines resource-specific configuration and behavior
+type TestResourceConfig[T TestResource] struct {
+	// ServiceName for labeling (e.g., "tempest", "tobiko")
+	ServiceName string
+
+	// NeedsNetworkAttachments indicates if NADs should be handled
+	NeedsNetworkAttachments bool
+
+	// NeedsConfigMaps indicates if ServiceConfigReadyCondition is needed
+	NeedsConfigMaps bool
+
+	// NeedsFinalizer indicates if the controller needs finalizer handling
+	NeedsFinalizer bool
+
+	// SupportsWorkflow indicates if the controller supports workflow feature
+	SupportsWorkflow bool
+
+	// GenerateServiceConfigMaps creates resource-specific config maps
+	GenerateServiceConfigMaps func(ctx context.Context, helper *helper.Helper, labels map[string]string, instance T, workflowStepIndex int) error
+
+	// BuildPod creates the resource-specific pod definition
+	BuildPod func(ctx context.Context, instance T, labels, annotations map[string]string, workflowStepIndex int, pvcIndex int) (*corev1.Pod, error)
+
+	// GetInitialConditions returns the condition list for a new instance
+	GetInitialConditions func() []*condition.Condition
+
+	// ValidateInputs validates resource-specific inputs
+	ValidateInputs func(ctx context.Context, instance T) error
+
+	// Optional filed accessors
+	GetParallel                func(instance T) bool
+	GetNetworkAttachments      func(instance T) []string
+	GetNetworkAttachmentStatus func(instance T) *map[string][]string
+
+	// Optional filed accessors - workflow support
+	GetSpec           func(instance T) interface{}
+	GetWorkflowStep   func(instance T, step int) interface{}
+	GetWorkflowLength func(instance T) int
+}
+
+// CommonReconcile executes the standard reconciliation workflow using generics
+func CommonReconcile[T TestResource](
+	ctx context.Context,
+	r *Reconciler,
+	req ctrl.Request,
+	instance T,
+	config TestResourceConfig[T],
+	Log logr.Logger,
+) (result ctrl.Result, _err error) {
+	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Create a helper
+	helper, err := helper.NewHelper(
+		instance,
+		r.Client,
+		r.Kclient,
+		r.Scheme,
+		r.Log,
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Get conditions from instance
+	conditions := instance.GetConditions()
+
+	// Initialize status
+	isNewInstance := len(*conditions) == 0
+	if isNewInstance {
+		*conditions = condition.Conditions{}
+	}
+
+	// Save a copy of the conditions so that we can restore the LastTransitionTime
+	// when a condition's state doesn't change.
+	savedConditions := conditions.DeepCopy()
+
+	// Always patch the instance status when exiting this function so we
+	// can persist any changes.
+	defer func() {
+		// Don't update the status, if reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
+			panic(r)
+		}
+		condition.RestoreLastTransitionTimes(conditions, savedConditions)
+		if conditions.IsUnknown(condition.ReadyCondition) {
+			conditions.Set(conditions.Mirror(condition.ReadyCondition))
+		}
+		err := helper.PatchInstance(ctx, instance)
+		if err != nil {
+			_err = err
+			return
+		}
+	}()
+
+	if isNewInstance {
+		// Initialize conditions used later as Status=Unknown
+		cl := condition.CreateList(config.GetInitialConditions()...)
+		conditions.Init(&cl)
+
+		// Register overall status immediately to have an early feedback
+		// e.g. in the cli
+		return ctrl.Result{}, nil
+	}
+	instance.SetObservedGeneration()
+
+	// If we're not deleting this and the service object doesn't have our
+	// finalizer, add it.
+	if config.NeedsFinalizer && instance.GetDeletionTimestamp().IsZero() &&
+		controllerutil.AddFinalizer(instance, helper.GetFinalizer()) {
+		return ctrl.Result{}, nil
+	}
+
+	// Handle service delete
+	if config.NeedsFinalizer && !instance.GetDeletionTimestamp().IsZero() {
+		Log.Info("Reconciling Service delete")
+		controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
+		Log.Info("Reconciled Service delete successfully")
+		return ctrl.Result{}, nil
+	}
+
+	if config.NeedsNetworkAttachments {
+		networkStatus := config.GetNetworkAttachmentStatus(instance)
+		if networkStatus != nil && *networkStatus == nil {
+			*networkStatus = map[string][]string{}
+		}
+	}
+
+	workflowLength := 0
+	if config.SupportsWorkflow {
+		workflowLength = config.GetWorkflowLength(instance)
+	}
+
+	nextAction, workflowStepIndex, err := r.NextAction(ctx, instance, workflowLength)
+
+	// Apply workflow step overrides to the base spec
+	if config.SupportsWorkflow && workflowStepIndex < workflowLength {
+		spec := config.GetSpec(instance)
+		workflowStepData := config.GetWorkflowStep(instance, workflowStepIndex)
+		MergeSections(spec, workflowStepData)
+	}
+
+	parallel := false
+	if config.GetParallel != nil {
+		parallel = config.GetParallel(instance)
+	}
+
+	pvcIndex := 0
+	// Create multiple PVCs for parallel execution
+	if parallel && config.SupportsWorkflow && workflowStepIndex < workflowLength {
+		pvcIndex = workflowStepIndex
+	}
+
+	switch nextAction {
+	case Failure:
+		return ctrl.Result{}, err
+
+	case Wait:
+		Log.Info(InfoWaitingOnPod)
+		return ctrl.Result{RequeueAfter: RequeueAfterValue}, nil
+
+	case EndTesting:
+		// All pods created by the instance were completed. Release the lock
+		// so that other instances can spawn their pods.
+		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
+			Log.Info(fmt.Sprintf(InfoCanNotReleaseLock, testOperatorLockName))
+			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
+		}
+
+		conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+
+		if conditions.AllSubConditionIsTrue() {
+			conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		}
+
+		Log.Info(InfoTestingCompleted)
+		return ctrl.Result{}, nil
+
+	case CreateFirstPod:
+		lockAcquired, err := r.AcquireLock(ctx, instance, helper, parallel)
+		if !lockAcquired {
+			Log.Info(fmt.Sprintf(InfoCanNotAcquireLock, testOperatorLockName))
+			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
+		}
+
+		Log.Info(fmt.Sprintf(InfoCreatingFirstPod, workflowStepIndex))
+
+	case CreateNextPod:
+		// Confirm that we still hold the lock. This is useful to check if for
+		// example somebody / something deleted the lock and it got claimed by
+		// another instance. This is considered to be an error state.
+		lockAcquired, err := r.AcquireLock(ctx, instance, helper, parallel)
+		if !lockAcquired {
+			Log.Error(err, fmt.Sprintf(ErrConfirmLockOwnership, testOperatorLockName))
+			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
+		}
+
+		Log.Info(fmt.Sprintf(InfoCreatingNextPod, workflowStepIndex))
+
+	default:
+		return ctrl.Result{}, ErrReceivedUnexpectedAction
+	}
+
+	serviceLabels := map[string]string{
+		common.AppSelector: config.ServiceName,
+		workflowStepLabel:  strconv.Itoa(workflowStepIndex),
+		instanceNameLabel:  instance.GetName(),
+		operatorNameLabel:  "test-operator",
+	}
+
+	// Validate inputs
+	if config.ValidateInputs != nil {
+		if err := config.ValidateInputs(ctx, instance); err != nil {
+			conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityError,
+				condition.InputReadyErrorMessage,
+				err.Error()))
+			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
+		}
+		conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
+	}
+
+	// Create PersistentVolumeClaim
+	ctrlResult, err := r.EnsureLogsPVCExists(
+		ctx,
+		instance,
+		helper,
+		serviceLabels,
+		instance.GetStorageClass(),
+		pvcIndex,
+	)
+	if err != nil {
+		return ctrlResult, err
+	} else if (ctrlResult != ctrl.Result{}) {
+		return ctrlResult, nil
+	}
+
+	// Generate ConfigMaps containing test configuration
+	if config.NeedsConfigMaps {
+		err = config.GenerateServiceConfigMaps(ctx, helper, serviceLabels, instance, workflowStepIndex)
+		if err != nil {
+			conditions.Set(condition.FalseCondition(
+				condition.ServiceConfigReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.ServiceConfigReadyErrorMessage,
+				err.Error()))
+			return ctrl.Result{}, err
+		}
+		conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
+	}
+
+	var serviceAnnotations map[string]string
+	if config.NeedsNetworkAttachments {
+		annotations, ctrlResult, err := r.EnsureNetworkAttachments(
+			ctx,
+			Log,
+			helper,
+			config.GetNetworkAttachments(instance),
+			instance.GetNamespace(),
+			conditions,
+		)
+		if err != nil || (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, err
+		}
+		serviceAnnotations = annotations
+	}
+
+	// Build pod
+	podDef, err := config.BuildPod(
+		ctx,
+		instance,
+		serviceLabels,
+		serviceAnnotations,
+		workflowStepIndex,
+		pvcIndex,
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Create a new pod
+	ctrlResult, err = r.CreatePod(ctx, *helper, podDef)
+	if err != nil {
+		// Release the lock and allow other controllers to spawn
+		// a pod.
+		if lockReleased, lockErr := r.ReleaseLock(ctx, instance); !lockReleased {
+			return ctrl.Result{RequeueAfter: RequeueAfterValue}, lockErr
+		}
+		conditions.Set(condition.FalseCondition(
+			condition.DeploymentReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.DeploymentReadyErrorMessage,
+			err.Error()))
+		return ctrlResult, err
+	} else if (ctrlResult != ctrl.Result{}) {
+		conditions.Set(condition.FalseCondition(
+			condition.DeploymentReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DeploymentReadyRunningMessage))
+		return ctrlResult, nil
+	}
+
+	if config.NeedsNetworkAttachments {
+		ctrlResult, err = r.VerifyNetworkAttachments(
+			ctx,
+			helper,
+			instance,
+			config.GetNetworkAttachments(instance),
+			serviceLabels,
+			workflowStepIndex,
+			conditions,
+			config.GetNetworkAttachmentStatus(instance),
+		)
+		if err != nil || (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, err
+		}
+	}
+
+	// Mark ready if all conditions are true
+	if conditions.AllSubConditionIsTrue() {
+		conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+	}
+
+	Log.Info("Reconciled Service successfully")
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/horizontest_controller.go
+++ b/internal/controller/horizontest_controller.go
@@ -18,17 +18,14 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	testv1beta1 "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/test-operator/internal/horizontest"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -54,242 +51,77 @@ func (r *HorizonTestReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
 
 // Reconcile - HorizonTest
-func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	Log := r.GetLogger(ctx)
+func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	instance := &testv1beta1.HorizonTest{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+
+	config := TestResourceConfig[*testv1beta1.HorizonTest]{
+		ServiceName:             horizontest.ServiceName,
+		NeedsNetworkAttachments: false,
+		NeedsConfigMaps:         true,
+		NeedsFinalizer:          false,
+		SupportsWorkflow:        false,
+
+		GenerateServiceConfigMaps: func(ctx context.Context, helper *helper.Helper, labels map[string]string, instance *testv1beta1.HorizonTest, _ int) error {
+			return r.generateServiceConfigMaps(ctx, helper, labels, instance)
+		},
+
+		BuildPod: func(ctx context.Context, instance *testv1beta1.HorizonTest, labels, annotations map[string]string, workflowStepIndex int, pvcIndex int) (*corev1.Pod, error) {
+			return r.buildHorizonTestPod(ctx, instance, labels, annotations, workflowStepIndex, pvcIndex)
+		},
+
+		GetInitialConditions: func() []*condition.Condition {
+			return []*condition.Condition{
+				condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
+				condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+				condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+				condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+			}
+		},
+
+		ValidateInputs: func(ctx context.Context, instance *testv1beta1.HorizonTest) error {
+			if err := r.ValidateOpenstackInputs(ctx, instance, instance.Spec.OpenStackConfigMap, instance.Spec.OpenStackConfigSecret); err != nil {
+				return err
+			}
+			return r.ValidateSecretWithKeys(ctx, instance, instance.Spec.KubeconfigSecretName, []string{})
+		},
+
+		GetParallel: func(instance *testv1beta1.HorizonTest) bool {
+			return instance.Spec.Parallel
+		},
 	}
 
-	helper, err := helper.NewHelper(
-		instance,
-		r.Client,
-		r.Kclient,
-		r.Scheme,
-		r.Log,
-	)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	return CommonReconcile(ctx, &r.Reconciler, req, instance, config, r.GetLogger(ctx))
+}
 
-	// initialize status
-	isNewInstance := instance.Status.Conditions == nil
-	if isNewInstance {
-		instance.Status.Conditions = condition.Conditions{}
-	}
-
-	// Save a copy of the conditions so that we can restore the LastTransitionTime
-	// when a condition's state doesn't change.
-	savedConditions := instance.Status.Conditions.DeepCopy()
-
-	// Always patch the instance status when exiting this function so we
-	// can persist any changes.
-	defer func() {
-		// Don't update the status, if reconciler Panics
-		if r := recover(); r != nil {
-			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
-			panic(r)
-		}
-		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
-		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
-			instance.Status.Conditions.Set(
-				instance.Status.Conditions.Mirror(condition.ReadyCondition))
-		}
-		err := helper.PatchInstance(ctx, instance)
-		if err != nil {
-			_err = err
-			return
-		}
-	}()
-
-	if isNewInstance {
-		// Initialize conditions used later as Status=Unknown
-		cl := condition.CreateList(
-			condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
-			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
-			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
-		)
-		instance.Status.Conditions.Init(&cl)
-
-		// Register overall status immediately to have an early feedback
-		// e.g. in the cli
-		return ctrl.Result{}, nil
-	}
-	instance.Status.ObservedGeneration = instance.Generation
-
-	workflowLength := 0
-	nextAction, workflowStepIndex, err := r.NextAction(ctx, instance, workflowLength)
-
-	switch nextAction {
-	case Failure:
-		return ctrl.Result{}, err
-
-	case Wait:
-		Log.Info(InfoWaitingOnPod)
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, nil
-
-	case EndTesting:
-		// All pods created by the instance were completed. Release the lock
-		// so that other instances can spawn their pods.
-		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
-			Log.Info(fmt.Sprintf(InfoCanNotReleaseLock, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		instance.Status.Conditions.MarkTrue(
-			condition.DeploymentReadyCondition,
-			condition.DeploymentReadyMessage)
-
-		if instance.Status.Conditions.AllSubConditionIsTrue() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
-		}
-
-		Log.Info(InfoTestingCompleted)
-		return ctrl.Result{}, nil
-
-	case CreateFirstPod:
-		lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
-		if !lockAcquired {
-			Log.Info(fmt.Sprintf(InfoCanNotAcquireLock, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		Log.Info(fmt.Sprintf(InfoCreatingFirstPod, workflowStepIndex))
-
-	case CreateNextPod:
-		// Confirm that we still hold the lock. This is useful to check if for
-		// example somebody / something deleted the lock and it got claimed by
-		// another instance. This is considered to be an error state.
-		lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
-		if !lockAcquired {
-			Log.Error(err, fmt.Sprintf(ErrConfirmLockOwnership, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		Log.Info(fmt.Sprintf(InfoCreatingNextPod, workflowStepIndex))
-
-	default:
-		return ctrl.Result{}, ErrReceivedUnexpectedAction
-	}
-
-	serviceLabels := map[string]string{
-		common.AppSelector: horizontest.ServiceName,
-		instanceNameLabel:  instance.Name,
-		operatorNameLabel:  "test-operator",
-
-		// NOTE(lpiwowar):  This is a workaround since the Horizontest CR does not support
-		//                  workflows. However, the label might be required by automation that
-		//                  consumes the test-operator (e.g., ci-framework).
-		workflowStepLabel: "0",
-	}
-
-	err = r.ValidateOpenstackInputs(ctx, instance, instance.Spec.OpenStackConfigMap, instance.Spec.OpenStackConfigSecret)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityError,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-	}
-
-	err = r.ValidateSecretWithKeys(ctx, instance, instance.Spec.KubeconfigSecretName, []string{})
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	mountKubeconfig := len(instance.Spec.KubeconfigSecretName) != 0
-	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
-
-	// Generate ConfigMaps
-	err = r.generateServiceConfigMaps(ctx, helper, serviceLabels, instance)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
-	// Generate ConfigMaps - end
-
-	// Create PersistentVolumeClaim
-	ctrlResult, err := r.EnsureLogsPVCExists(
-		ctx,
-		instance,
-		helper,
-		serviceLabels,
-		instance.Spec.StorageClass,
-		0,
-	)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-	// Create PersistentVolumeClaim - end
-
-	// Create Pod
+func (r *HorizonTestReconciler) buildHorizonTestPod(
+	ctx context.Context,
+	instance *testv1beta1.HorizonTest,
+	labels, _ map[string]string,
+	workflowStepIndex int,
+	pvcIndex int,
+) (*corev1.Pod, error) {
 	mountCerts := r.CheckSecretExists(ctx, instance, "combined-ca-bundle")
+	mountKubeconfig := len(instance.Spec.KubeconfigSecretName) != 0
 
-	// Prepare HorizonTest env vars
 	envVars := r.PrepareHorizonTestEnvVars(instance)
-	podName := r.GetPodName(instance, 0)
-	logsPVCName := r.GetPVCLogsName(instance, 0)
+	podName := r.GetPodName(instance, workflowStepIndex)
+	logsPVCName := r.GetPVCLogsName(instance, pvcIndex)
+
 	containerImage, err := r.GetContainerImage(ctx, instance)
 	if err != nil {
-		return ctrl.Result{}, err
+		return nil, err
 	}
 
-	podDef := horizontest.Pod(
+	return horizontest.Pod(
 		instance,
-		serviceLabels,
+		labels,
 		podName,
 		logsPVCName,
 		mountCerts,
 		mountKubeconfig,
 		envVars,
 		containerImage,
-	)
-
-	ctrlResult, err = r.CreatePod(ctx, *helper, podDef)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.DeploymentReadyErrorMessage,
-			err.Error()))
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.DeploymentReadyRunningMessage))
-		return ctrlResult, nil
-	}
-	// create Pod - end
-
-	if instance.Status.Conditions.AllSubConditionIsTrue() {
-		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
-	}
-
-	Log.Info("Reconciled Service successfully")
-	return ctrl.Result{}, nil
+	), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/tempest_controller.go
+++ b/internal/controller/tempest_controller.go
@@ -18,11 +18,9 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/go-logr/logr"
-	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -31,9 +29,7 @@ import (
 	testv1beta1 "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/test-operator/internal/tempest"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -58,247 +54,93 @@ func (r *TempestReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
 
 // Reconcile - Tempest
-func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
-	Log := r.GetLogger(ctx)
-
-	// Fetch the Tempest instance
+func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	instance := &testv1beta1.Tempest{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+
+	config := TestResourceConfig[*testv1beta1.Tempest]{
+		ServiceName:             tempest.ServiceName,
+		NeedsNetworkAttachments: true,
+		NeedsConfigMaps:         true,
+		NeedsFinalizer:          true,
+		SupportsWorkflow:        true,
+
+		GenerateServiceConfigMaps: func(ctx context.Context, helper *helper.Helper, _ map[string]string, instance *testv1beta1.Tempest, workflowStep int) error {
+			return r.generateServiceConfigMaps(ctx, helper, instance, workflowStep)
+		},
+
+		BuildPod: func(ctx context.Context, instance *testv1beta1.Tempest, labels, annotations map[string]string, workflowStepIndex int, pvcIndex int) (*corev1.Pod, error) {
+			return r.buildTempestPod(ctx, instance, labels, annotations, workflowStepIndex, pvcIndex)
+		},
+
+		GetInitialConditions: func() []*condition.Condition {
+			return []*condition.Condition{
+				condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
+				condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+				condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+				condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+				condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
+			}
+		},
+
+		ValidateInputs: func(ctx context.Context, instance *testv1beta1.Tempest) error {
+			if err := r.ValidateOpenstackInputs(ctx, instance, instance.Spec.OpenStackConfigMap, instance.Spec.OpenStackConfigSecret); err != nil {
+				return err
+			}
+			return r.ValidateSecretWithKeys(ctx, instance, instance.Spec.SSHKeySecretName, []string{})
+		},
+
+		GetSpec: func(instance *testv1beta1.Tempest) interface{} {
+			return &instance.Spec
+		},
+
+		GetWorkflowStep: func(instance *testv1beta1.Tempest, step int) interface{} {
+			return instance.Spec.Workflow[step]
+		},
+
+		GetWorkflowLength: func(instance *testv1beta1.Tempest) int {
+			return len(instance.Spec.Workflow)
+		},
+
+		GetParallel: func(instance *testv1beta1.Tempest) bool {
+			return instance.Spec.Parallel
+		},
+
+		GetNetworkAttachments: func(instance *testv1beta1.Tempest) []string {
+			return instance.Spec.NetworkAttachments
+		},
+
+		GetNetworkAttachmentStatus: func(instance *testv1beta1.Tempest) *map[string][]string {
+			return &instance.Status.NetworkAttachments
+		},
 	}
 
-	// Create a helper
-	helper, err := helper.NewHelper(
-		instance,
-		r.Client,
-		r.Kclient,
-		r.Scheme,
-		r.Log,
-	)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	return CommonReconcile(ctx, &r.Reconciler, req, instance, config, r.GetLogger(ctx))
+}
 
-	// initialize status
-	isNewInstance := instance.Status.Conditions == nil
-	if isNewInstance {
-		instance.Status.Conditions = condition.Conditions{}
-	}
-
-	// Save a copy of the conditions so that we can restore the LastTransitionTime
-	// when a condition's state doesn't change.
-	savedConditions := instance.Status.Conditions.DeepCopy()
-
-	// Always patch the instance status when exiting this function so we
-	// can persist any changes.
-	defer func() {
-		// Don't update the status, if reconciler Panics
-		if r := recover(); r != nil {
-			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
-			panic(r)
-		}
-		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
-		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
-			instance.Status.Conditions.Set(
-				instance.Status.Conditions.Mirror(condition.ReadyCondition))
-		}
-		err := helper.PatchInstance(ctx, instance)
-		if err != nil {
-			_err = err
-			return
-		}
-	}()
-
-	if isNewInstance {
-		// Initialize conditions used later as Status=Unknown
-		cl := condition.CreateList(
-			condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
-			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
-			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
-			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
-		)
-		instance.Status.Conditions.Init(&cl)
-
-		// Register overall status immediately to have an early feedback
-		// e.g. in the cli
-		return ctrl.Result{}, nil
-	}
-	instance.Status.ObservedGeneration = instance.Generation
-
-	// If we're not deleting this and the service object doesn't have our
-	// finalizer, add it.
-	if instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer()) {
-		return ctrl.Result{}, nil
-	}
-
-	if instance.Status.NetworkAttachments == nil {
-		instance.Status.NetworkAttachments = map[string][]string{}
-	}
-
-	// Handle service delete
-	if !instance.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, instance, helper)
-	}
-
-	workflowLength := len(instance.Spec.Workflow)
-	nextAction, workflowStepIndex, err := r.NextAction(ctx, instance, workflowLength)
-	if workflowStepIndex < workflowLength {
-		MergeSections(&instance.Spec, instance.Spec.Workflow[workflowStepIndex])
-	}
-
-	switch nextAction {
-	case Failure:
-		return ctrl.Result{}, err
-
-	case Wait:
-		Log.Info(InfoWaitingOnPod)
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, nil
-
-	case EndTesting:
-		// All pods created by the instance were completed. Release the lock
-		// so that other instances can spawn their pods.
-		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
-			Log.Info(fmt.Sprintf(InfoCanNotReleaseLock, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		instance.Status.Conditions.MarkTrue(
-			condition.DeploymentReadyCondition,
-			condition.DeploymentReadyMessage)
-
-		if instance.Status.Conditions.AllSubConditionIsTrue() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
-		}
-
-		Log.Info(InfoTestingCompleted)
-		return ctrl.Result{}, nil
-
-	case CreateFirstPod:
-		lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
-		if !lockAcquired {
-			Log.Info(fmt.Sprintf(InfoCanNotAcquireLock, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		Log.Info(fmt.Sprintf(InfoCreatingFirstPod, workflowStepIndex))
-
-	case CreateNextPod:
-		// Confirm that we still hold the lock. This is useful to check if for
-		// example somebody / something deleted the lock and it got claimed by
-		// another instance. This is considered to be an error state.
-		lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
-		if !lockAcquired {
-			Log.Error(err, fmt.Sprintf(ErrConfirmLockOwnership, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		Log.Info(fmt.Sprintf(InfoCreatingNextPod, workflowStepIndex))
-
-	default:
-		return ctrl.Result{}, ErrReceivedUnexpectedAction
-	}
-
-	serviceLabels := map[string]string{
-		common.AppSelector: tempest.ServiceName,
-		workflowStepLabel:  strconv.Itoa(workflowStepIndex),
-		instanceNameLabel:  instance.Name,
-		operatorNameLabel:  "test-operator",
-	}
-
-	pvcIndex := 0
-	// Create multiple PVCs for parallel execution
-	if instance.Spec.Parallel && workflowStepIndex < len(instance.Spec.Workflow) {
-		pvcIndex = workflowStepIndex
-	}
-
-	err = r.ValidateOpenstackInputs(ctx, instance, instance.Spec.OpenStackConfigMap, instance.Spec.OpenStackConfigSecret)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityError,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-	}
-
-	err = r.ValidateSecretWithKeys(ctx, instance, instance.Spec.SSHKeySecretName, []string{})
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
+func (r *TempestReconciler) buildTempestPod(
+	ctx context.Context,
+	instance *testv1beta1.Tempest,
+	labels, annotations map[string]string,
+	workflowStepIndex int,
+	pvcIndex int,
+) (*corev1.Pod, error) {
 	mountSSHKey := len(instance.Spec.SSHKeySecretName) != 0
-
-	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
-
-	// Create PersistentVolumeClaim
-	ctrlResult, err := r.EnsureLogsPVCExists(
-		ctx,
-		instance,
-		helper,
-		serviceLabels,
-		instance.Spec.StorageClass,
-		pvcIndex,
-	)
-
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-	// Create PersistentVolumeClaim - end
-
-	// Generate ConfigMaps
-	err = r.generateServiceConfigMaps(ctx, helper, instance, workflowStepIndex)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
-	// Generate ConfigMaps - end
-
-	serviceAnnotations, ctrlResult, err := r.EnsureNetworkAttachments(
-		ctx,
-		Log,
-		helper,
-		instance.Spec.NetworkAttachments,
-		instance.Namespace,
-		&instance.Status.Conditions,
-	)
-	if err != nil || (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, err
-	}
-
-	// Create a new pod
 	mountCerts := r.CheckSecretExists(ctx, instance, "combined-ca-bundle")
+
 	customDataConfigMapName := GetCustomDataConfigMapName(instance, workflowStepIndex)
 	envVarsConfigMapName := GetEnvVarsConfigMapName(instance, workflowStepIndex)
 	podName := r.GetPodName(instance, workflowStepIndex)
 	logsPVCName := r.GetPVCLogsName(instance, pvcIndex)
+
 	containerImage, err := r.GetContainerImage(ctx, instance)
 	if err != nil {
-		return ctrl.Result{}, err
+		return nil, err
 	}
 
-	podDef := tempest.Pod(
+	return tempest.Pod(
 		instance,
-		serviceLabels,
-		serviceAnnotations,
+		labels,
+		annotations,
 		podName,
 		envVarsConfigMapName,
 		customDataConfigMapName,
@@ -306,70 +148,7 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		mountCerts,
 		mountSSHKey,
 		containerImage,
-	)
-
-	ctrlResult, err = r.CreatePod(ctx, *helper, podDef)
-	if err != nil {
-		// Creation of the tempest pod was not successful.
-		// Release the lock and allow other controllers to spawn
-		// a pod.
-		if lockReleased, lockErr := r.ReleaseLock(ctx, instance); !lockReleased {
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, lockErr
-		}
-
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.DeploymentReadyErrorMessage,
-			err.Error()))
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.DeploymentReadyRunningMessage))
-		return ctrlResult, nil
-	}
-	// Create a new pod - end
-
-	// NetworkAttachments
-	ctrlResult, err = r.VerifyNetworkAttachments(
-		ctx,
-		helper,
-		instance,
-		instance.Spec.NetworkAttachments,
-		serviceLabels,
-		workflowStepIndex,
-		&instance.Status.Conditions,
-		&instance.Status.NetworkAttachments,
-	)
-	if err != nil || (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, err
-	}
-
-	if instance.Status.Conditions.AllSubConditionIsTrue() {
-		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
-	}
-
-	return ctrl.Result{}, nil
-}
-
-func (r *TempestReconciler) reconcileDelete(
-	ctx context.Context,
-	instance *testv1beta1.Tempest,
-	helper *helper.Helper,
-) (ctrl.Result, error) {
-	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service delete")
-
-	// remove the finalizer
-	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
-
-	Log.Info("Reconciled Service delete successfully")
-
-	return ctrl.Result{}, nil
+	), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/tobiko_controller.go
+++ b/internal/controller/tobiko_controller.go
@@ -18,11 +18,9 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/go-logr/logr"
-	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -31,7 +29,6 @@ import (
 	testv1beta1 "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/test-operator/internal/tobiko"
 	corev1 "k8s.io/api/core/v1"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -57,235 +54,80 @@ func (r *TobikoReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;create;update;watch;patch;delete
 
 // Reconcile - Tobiko
-func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
+func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	instance := &testv1beta1.Tobiko{}
+
+	config := TestResourceConfig[*testv1beta1.Tobiko]{
+		ServiceName:             tobiko.ServiceName,
+		NeedsNetworkAttachments: true,
+		NeedsConfigMaps:         true,
+		NeedsFinalizer:          false,
+		SupportsWorkflow:        true,
+
+		GenerateServiceConfigMaps: func(ctx context.Context, helper *helper.Helper, labels map[string]string, instance *testv1beta1.Tobiko, workflowStepIndex int) error {
+			return r.generateServiceConfigMaps(ctx, helper, labels, instance, workflowStepIndex)
+		},
+
+		BuildPod: func(ctx context.Context, instance *testv1beta1.Tobiko, labels, annotations map[string]string, workflowStepIndex int, pvcIndex int) (*corev1.Pod, error) {
+			return r.buildTobikoPod(ctx, instance, labels, annotations, workflowStepIndex, pvcIndex)
+		},
+
+		GetInitialConditions: func() []*condition.Condition {
+			return []*condition.Condition{
+				condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
+				condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+				condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+				condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+				condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
+			}
+		},
+
+		ValidateInputs: func(ctx context.Context, instance *testv1beta1.Tobiko) error {
+			if err := r.ValidateOpenstackInputs(ctx, instance, instance.Spec.OpenStackConfigMap, instance.Spec.OpenStackConfigSecret); err != nil {
+				return err
+			}
+			return r.ValidateSecretWithKeys(ctx, instance, instance.Spec.KubeconfigSecretName, []string{})
+		},
+
+		GetSpec: func(instance *testv1beta1.Tobiko) interface{} {
+			return &instance.Spec
+		},
+
+		GetWorkflowStep: func(instance *testv1beta1.Tobiko, step int) interface{} {
+			return instance.Spec.Workflow[step]
+		},
+
+		GetWorkflowLength: func(instance *testv1beta1.Tobiko) int {
+			return len(instance.Spec.Workflow)
+		},
+
+		GetParallel: func(instance *testv1beta1.Tobiko) bool {
+			return instance.Spec.Parallel
+		},
+
+		GetNetworkAttachments: func(instance *testv1beta1.Tobiko) []string {
+			return instance.Spec.NetworkAttachments
+		},
+
+		GetNetworkAttachmentStatus: func(instance *testv1beta1.Tobiko) *map[string][]string {
+			return &instance.Status.NetworkAttachments
+		},
+	}
+
+	return CommonReconcile(ctx, &r.Reconciler, req, instance, config, r.GetLogger(ctx))
+}
+
+func (r *TobikoReconciler) buildTobikoPod(
+	ctx context.Context,
+	instance *testv1beta1.Tobiko,
+	labels, annotations map[string]string,
+	workflowStepIndex int,
+	pvcIndex int,
+) (*corev1.Pod, error) {
 	Log := r.GetLogger(ctx)
 
-	instance := &testv1beta1.Tobiko{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
-	}
-
-	helper, err := helper.NewHelper(
-		instance,
-		r.Client,
-		r.Kclient,
-		r.Scheme,
-		r.Log,
-	)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// initialize status
-	isNewInstance := instance.Status.Conditions == nil
-	if isNewInstance {
-		instance.Status.Conditions = condition.Conditions{}
-	}
-
-	// Save a copy of the conditions so that we can restore the LastTransitionTime
-	// when a condition's state doesn't change.
-	savedConditions := instance.Status.Conditions.DeepCopy()
-
-	// Always patch the instance status when exiting this function so we
-	// can persist any changes.
-	defer func() {
-		// Don't update the status, if reconciler Panics
-		if r := recover(); r != nil {
-			Log.Info(fmt.Sprintf("panic during reconcile %v\n", r))
-			panic(r)
-		}
-		condition.RestoreLastTransitionTimes(&instance.Status.Conditions, savedConditions)
-		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
-			instance.Status.Conditions.Set(
-				instance.Status.Conditions.Mirror(condition.ReadyCondition))
-		}
-		err := helper.PatchInstance(ctx, instance)
-		if err != nil {
-			_err = err
-			return
-		}
-	}()
-
-	if isNewInstance {
-		// Initialize conditions used later as Status=Unknown
-		cl := condition.CreateList(
-			condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
-			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
-			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
-			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
-		)
-		instance.Status.Conditions.Init(&cl)
-
-		// Register overall status immediately to have an early feedback
-		// e.g. in the cli
-		return ctrl.Result{}, nil
-	}
-	instance.Status.ObservedGeneration = instance.Generation
-
-	if instance.Status.NetworkAttachments == nil {
-		instance.Status.NetworkAttachments = map[string][]string{}
-	}
-
-	workflowLength := len(instance.Spec.Workflow)
-	nextAction, workflowStepIndex, err := r.NextAction(ctx, instance, workflowLength)
-	if workflowStepIndex < workflowLength {
-		MergeSections(&instance.Spec, instance.Spec.Workflow[workflowStepIndex])
-	}
-
-	switch nextAction {
-	case Failure:
-		return ctrl.Result{}, err
-
-	case Wait:
-		Log.Info(InfoWaitingOnPod)
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, nil
-
-	case EndTesting:
-		// All pods created by the instance were completed. Release the lock
-		// so that other instances can spawn their pods.
-		if lockReleased, err := r.ReleaseLock(ctx, instance); !lockReleased {
-			Log.Info(fmt.Sprintf(InfoCanNotReleaseLock, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		instance.Status.Conditions.MarkTrue(
-			condition.DeploymentReadyCondition,
-			condition.DeploymentReadyMessage)
-
-		if instance.Status.Conditions.AllSubConditionIsTrue() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
-		}
-
-		Log.Info(InfoTestingCompleted)
-		return ctrl.Result{}, nil
-
-	case CreateFirstPod:
-		lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
-		if !lockAcquired {
-			Log.Info(fmt.Sprintf(InfoCanNotAcquireLock, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		Log.Info(fmt.Sprintf(InfoCreatingFirstPod, workflowStepIndex))
-
-	case CreateNextPod:
-		// Confirm that we still hold the lock. This needs to be checked in order
-		// to prevent situation when somebody / something deleted the lock and it
-		// got claimed by another instance.
-		lockAcquired, err := r.AcquireLock(ctx, instance, helper, instance.Spec.Parallel)
-		if !lockAcquired {
-			Log.Error(err, fmt.Sprintf(ErrConfirmLockOwnership, testOperatorLockName))
-			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-		}
-
-		Log.Info(fmt.Sprintf(InfoCreatingNextPod, workflowStepIndex))
-
-	default:
-		return ctrl.Result{}, ErrReceivedUnexpectedAction
-	}
-
-	serviceLabels := map[string]string{
-		common.AppSelector: tobiko.ServiceName,
-		workflowStepLabel:  strconv.Itoa(workflowStepIndex),
-		instanceNameLabel:  instance.Name,
-		operatorNameLabel:  "test-operator",
-	}
-
-	err = r.ValidateOpenstackInputs(ctx, instance, instance.Spec.OpenStackConfigMap, instance.Spec.OpenStackConfigSecret)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityError,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
-	}
-
-	err = r.ValidateSecretWithKeys(ctx, instance, instance.Spec.KubeconfigSecretName, []string{})
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	mountKubeconfig := len(instance.Spec.KubeconfigSecretName) != 0
-
-	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
-
-	// Generate ConfigMaps
-	err = r.generateServiceConfigMaps(ctx, helper, serviceLabels, instance, workflowStepIndex)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.ServiceConfigReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.ServiceConfigReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
-	// Generate ConfigMaps - end
-
-	pvcIndex := 0
-	// Create multiple PVCs for parallel execution
-	if instance.Spec.Parallel && workflowStepIndex < len(instance.Spec.Workflow) {
-		pvcIndex = workflowStepIndex
-	}
-
-	// Create PersistentVolumeClaim
-	ctrlResult, err := r.EnsureLogsPVCExists(
-		ctx,
-		instance,
-		helper,
-		serviceLabels,
-		instance.Spec.StorageClass,
-		pvcIndex,
-	)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-	// Create PersistentVolumeClaim - end
-
-	serviceAnnotations, ctrlResult, err := r.EnsureNetworkAttachments(
-		ctx,
-		Log,
-		helper,
-		instance.Spec.NetworkAttachments,
-		instance.Namespace,
-		&instance.Status.Conditions,
-	)
-	if err != nil || (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, err
-	}
-
-	// NetworkAttachments
-	ctrlResult, err = r.VerifyNetworkAttachments(
-		ctx,
-		helper,
-		instance,
-		instance.Spec.NetworkAttachments,
-		serviceLabels,
-		workflowStepIndex,
-		&instance.Status.Conditions,
-		&instance.Status.NetworkAttachments,
-	)
-	if err != nil || (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, err
-	}
-
-	// Create Pod
 	mountCerts := r.CheckSecretExists(ctx, instance, "combined-ca-bundle")
+	mountKubeconfig := len(instance.Spec.KubeconfigSecretName) != 0
 	mountKeys := len(instance.Spec.PublicKey) > 0 && len(instance.Spec.PrivateKey) > 0
 	if !mountKeys {
 		Log.Info("Both values 'privateKey' and 'publicKey' need to be specified. Keys not mounted.")
@@ -295,15 +137,16 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	envVars := r.PrepareTobikoEnvVars(instance, workflowStepIndex)
 	podName := r.GetPodName(instance, workflowStepIndex)
 	logsPVCName := r.GetPVCLogsName(instance, pvcIndex)
+
 	containerImage, err := r.GetContainerImage(ctx, instance)
 	if err != nil {
-		return ctrl.Result{}, err
+		return nil, err
 	}
 
-	podDef := tobiko.Pod(
+	return tobiko.Pod(
 		instance,
-		serviceLabels,
-		serviceAnnotations,
+		labels,
+		annotations,
 		podName,
 		logsPVCName,
 		mountCerts,
@@ -312,33 +155,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		workflowStepIndex,
 		envVars,
 		containerImage,
-	)
-
-	ctrlResult, err = r.CreatePod(ctx, *helper, podDef)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.DeploymentReadyErrorMessage,
-			err.Error()))
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DeploymentReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.DeploymentReadyRunningMessage))
-		return ctrlResult, nil
-	}
-	// create Pod - end
-
-	if instance.Status.Conditions.AllSubConditionIsTrue() {
-		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
-	}
-
-	Log.Info("Reconciled Service successfully")
-	return ctrl.Result{}, nil
+	), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
To remove duplicate code across the test-operator controllers, this patch introduces a common controller. This change should make fixing controller bugs easier and prepare the test-operator for new resource addition, if it is needed in the future.

Assisted-by: Claude AI