### PR TITLE
Remove GetDefaultBool function

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -508,15 +508,6 @@ func (r *Reconciler) GetScheme() *runtime.Scheme {
 	return r.Scheme
 }
 
-// GetDefaultBool returns the string representation of a boolean value with default handling
-func (r *Reconciler) GetDefaultBool(variable bool) string {
-	if variable {
-		return "true"
-	}
-
-	return "false"
-}
-
 // GetDefaultInt returns the string representation of an integer value with optional default value
 func (r *Reconciler) GetDefaultInt(variable int64, defaultValue ...string) string {
 	if variable != 0 {

--- a/controllers/horizontest_controller.go
+++ b/controllers/horizontest_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -289,7 +290,7 @@ func (r *HorizonTestReconciler) PrepareHorizonTestEnvVars(
 	envVars["PASSWORD"] = env.SetValue("horizontest")
 	envVars["FLAVOR_NAME"] = env.SetValue("m1.tiny")
 	envVars["HORIZON_KEYS_FOLDER"] = env.SetValue("/etc/test_operator")
-	envVars["HORIZONTEST_DEBUG_MODE"] = env.SetValue(r.GetDefaultBool(instance.Spec.Debug))
+	envVars["HORIZONTEST_DEBUG_MODE"] = env.SetValue(strconv.FormatBool(instance.Spec.Debug))
 	envVars["EXTRA_FLAG"] = env.SetValue(instance.Spec.ExtraFlag)
 	envVars["PROJECT_NAME_XPATH"] = env.SetValue(instance.Spec.ProjectNameXpath)
 

--- a/controllers/tempest_controller.go
+++ b/controllers/tempest_controller.go
@@ -443,7 +443,7 @@ func (r *TempestReconciler) setTempestConfigVars(envVars map[string]string,
 	}
 
 	for key, value := range tempestBoolEnvVars {
-		envVars[key] = r.GetDefaultBool(value)
+		envVars[key] = strconv.FormatBool(value)
 	}
 
 	// Int
@@ -534,7 +534,7 @@ func (r *TempestReconciler) setTempestconfConfigVars(
 	}
 
 	for key, value := range tempestconfBoolEnvVars {
-		envVars[key] = r.GetDefaultBool(value)
+		envVars[key] = strconv.FormatBool(value)
 	}
 
 	tempestconfIntEnvVars := map[string]int64{
@@ -591,10 +591,10 @@ func (r *TempestReconciler) generateServiceConfigMaps(
 	r.setTempestconfConfigVars(envVars, customData, instance)
 	r.setConfigOverwrite(customData, instance.Spec.ConfigOverwrite)
 
-	envVars["TEMPEST_DEBUG_MODE"] = r.GetDefaultBool(instance.Spec.Debug)
-	envVars["TEMPEST_CLEANUP"] = r.GetDefaultBool(instance.Spec.Cleanup)
-	envVars["TEMPEST_RERUN_FAILED_TESTS"] = r.GetDefaultBool(instance.Spec.RerunFailedTests)
-	envVars["TEMPEST_RERUN_OVERRIDE_STATUS"] = r.GetDefaultBool(instance.Spec.RerunOverrideStatus)
+	envVars["TEMPEST_DEBUG_MODE"] = strconv.FormatBool(instance.Spec.Debug)
+	envVars["TEMPEST_CLEANUP"] = strconv.FormatBool(instance.Spec.Cleanup)
+	envVars["TEMPEST_RERUN_FAILED_TESTS"] = strconv.FormatBool(instance.Spec.RerunFailedTests)
+	envVars["TEMPEST_RERUN_OVERRIDE_STATUS"] = strconv.FormatBool(instance.Spec.RerunOverrideStatus)
 	envVars["TEMPEST_TIMING_DATA_URL"] = instance.Spec.TimingDataUrl
 
 	cms := []util.Template{

--- a/controllers/tobiko_controller.go
+++ b/controllers/tobiko_controller.go
@@ -384,7 +384,7 @@ func (r *TobikoReconciler) PrepareTobikoEnvVars(
 	}
 
 	envVars["TOBIKO_KEYS_FOLDER"] = env.SetValue("/etc/test_operator")
-	envVars["TOBIKO_DEBUG_MODE"] = env.SetValue(r.GetDefaultBool(instance.Spec.Debug))
+	envVars["TOBIKO_DEBUG_MODE"] = env.SetValue(strconv.FormatBool(instance.Spec.Debug))
 	// Prepare env vars - end
 
 	if instance.Spec.Patch != (testv1beta1.PatchType{}) {


### PR DESCRIPTION
The GetDefaultBool function can be replaced with a simple strconv command. This patch is also a part of the test-operator refactor to make the code look more presentable.