### PR TITLE
Rename workflow number variables for clarity

### DIFF
--- a/internal/controller/horizontest_controller.go
+++ b/internal/controller/horizontest_controller.go
@@ -122,7 +122,7 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	instance.Status.ObservedGeneration = instance.Generation
 
 	workflowLength := 0
-	nextAction, nextWorkflowStep, err := r.NextAction(ctx, instance, workflowLength)
+	nextAction, workflowStepIndex, err := r.NextAction(ctx, instance, workflowLength)
 
 	switch nextAction {
 	case Failure:
@@ -158,7 +158,7 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
 		}
 
-		Log.Info(fmt.Sprintf(InfoCreatingFirstPod, nextWorkflowStep))
+		Log.Info(fmt.Sprintf(InfoCreatingFirstPod, workflowStepIndex))
 
 	case CreateNextPod:
 		// Confirm that we still hold the lock. This is useful to check if for
@@ -170,7 +170,7 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
 		}
 
-		Log.Info(fmt.Sprintf(InfoCreatingNextPod, nextWorkflowStep))
+		Log.Info(fmt.Sprintf(InfoCreatingNextPod, workflowStepIndex))
 
 	default:
 		return ctrl.Result{}, ErrReceivedUnexpectedAction


### PR DESCRIPTION
While working on a different refactor I noticed that the naming of workflow number variables is a bit misleading. The workflowStepNum variable is currently used for parallel execution, but it is not really clear from the code as it blends in with the workflowStep vairable. This change should better clarify the actual difference between these workflow number variables.