### PR TITLE
Fix Tobiko workflow ConfigMaps to use step-specific names

### DIFF
--- a/internal/controller/tobiko_controller.go
+++ b/internal/controller/tobiko_controller.go
@@ -315,6 +315,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		mountCerts,
 		mountKeys,
 		mountKubeconfig,
+		workflowStepIndex,
 		envVars,
 		containerImage,
 	)
@@ -403,37 +404,25 @@ func (r *TobikoReconciler) PrepareTobikoEnvVars(
 	}
 
 	// Prepare custom data
-	customData := make(map[string]string)
-	customData["tobiko.conf"] = instance.Spec.Config
+	templateSpecs := []struct {
+		infix string
+		key   string
+		value string
+	}{
+		{tobiko.ConfigMapInfixConfig, tobiko.ConfigFileName, instance.Spec.Config},
+		{tobiko.ConfigMapInfixPrivateKey, tobiko.PrivateKeyFileName, instance.Spec.PrivateKey},
+		{tobiko.ConfigMapInfixPublicKey, tobiko.PublicKeyFileName, instance.Spec.PublicKey},
+	}
 
-	privateKeyData := make(map[string]string)
-	privateKeyData["id_ecdsa"] = instance.Spec.PrivateKey
-
-	publicKeyData := make(map[string]string)
-	publicKeyData["id_ecdsa.pub"] = instance.Spec.PublicKey
-
-	cms := []util.Template{
-		{
-			Name:         instance.Name + "tobiko-config",
+	cms := make([]util.Template, 0, len(templateSpecs))
+	for _, spec := range templateSpecs {
+		cms = append(cms, util.Template{
+			Name:         tobiko.GetConfigMapName(instance, spec.infix, workflowStepIndex),
 			Namespace:    instance.Namespace,
 			InstanceType: instance.Kind,
 			Labels:       labels,
-			CustomData:   customData,
-		},
-		{
-			Name:         instance.Name + "tobiko-private-key",
-			Namespace:    instance.Namespace,
-			InstanceType: instance.Kind,
-			Labels:       labels,
-			CustomData:   privateKeyData,
-		},
-		{
-			Name:         instance.Name + "tobiko-public-key",
-			Namespace:    instance.Namespace,
-			InstanceType: instance.Kind,
-			Labels:       labels,
-			CustomData:   publicKeyData,
-		},
+			CustomData:   map[string]string{spec.key: spec.value},
+		})
 	}
 
 	err := configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)

--- a/internal/tobiko/pod.go
+++ b/internal/tobiko/pod.go
@@ -18,6 +18,7 @@ func Pod(
 	mountCerts bool,
 	mountKeys bool,
 	mountKubeconfig bool,
+	workflowStepIndex int,
 	envVars map[string]env.Setter,
 	containerImage string,
 ) *corev1.Pod {
@@ -39,6 +40,6 @@ func Pod(
 		instance.Spec.SELinuxLevel,
 		instance.Spec.Tolerations,
 		GetVolumeMounts(instance, mountCerts, mountKeys, mountKubeconfig, TobikoPropagation),
-		GetVolumes(instance, logsPVCName, mountCerts, mountKeys, mountKubeconfig, TobikoPropagation),
+		GetVolumes(instance, logsPVCName, mountCerts, mountKeys, mountKubeconfig, workflowStepIndex, TobikoPropagation),
 	)
 }

--- a/internal/tobiko/volumes.go
+++ b/internal/tobiko/volumes.go
@@ -1,17 +1,39 @@
 package tobiko
 
 import (
+	"strconv"
+
 	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	testv1beta1 "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/test-operator/internal/util"
 	corev1 "k8s.io/api/core/v1"
 )
 
+// Volume names for ConfigMap mounts
 const (
 	tobikoConfig     = "tobiko-config"
 	tobikoPrivateKey = "tobiko-private-key"
 	tobikoPublicKey  = "tobiko-public-key"
 )
+
+// ConfigMap name infixes used to construct workflow-step-specific ConfigMap names
+const (
+	ConfigMapInfixConfig     = "-" + tobikoConfig + "-"
+	ConfigMapInfixPrivateKey = "-" + tobikoPrivateKey + "-"
+	ConfigMapInfixPublicKey  = "-" + tobikoPublicKey + "-"
+)
+
+// ConfigMap data key names for file contents
+const (
+	ConfigFileName     = "tobiko.conf"
+	PrivateKeyFileName = "id_ecdsa"
+	PublicKeyFileName  = "id_ecdsa.pub"
+)
+
+// GetConfigMapName returns the name of the custom data ConfigMap for the given workflow step
+func GetConfigMapName(instance *testv1beta1.Tobiko, infix string, workflowStepIndex int) string {
+	return instance.Name + infix + strconv.Itoa(workflowStepIndex)
+}
 
 // GetVolumes - returns a list of volumes for the test pod
 func GetVolumes(
@@ -20,11 +42,12 @@ func GetVolumes(
 	mountCerts bool,
 	mountKeys bool,
 	mountKubeconfig bool,
+	workflowStepIndex int,
 	svc []storage.PropagationType,
 ) []corev1.Volume {
 
 	volumes := []corev1.Volume{
-		util.CreateConfigMapVolume(tobikoConfig, instance.Name+tobikoConfig, util.ScriptsVolumeDefaultMode),
+		util.CreateConfigMapVolume(tobikoConfig, GetConfigMapName(instance, ConfigMapInfixConfig, workflowStepIndex), util.ScriptsVolumeDefaultMode),
 		util.CreateOpenstackConfigMapVolume(util.TestOperatorCloudsConfigMapName),
 		util.CreateOpenstackConfigSecretVolume(instance.Spec.OpenStackConfigSecret),
 		util.CreateLogsPVCVolume(logsPVCName),
@@ -38,8 +61,8 @@ func GetVolumes(
 
 	if mountKeys {
 		volumes = append(volumes,
-			util.CreateConfigMapVolume(tobikoPrivateKey, instance.Name+tobikoPrivateKey, util.PrivateKeyMode),
-			util.CreateConfigMapVolume(tobikoPublicKey, instance.Name+tobikoPublicKey, util.PublicKeyMode),
+			util.CreateConfigMapVolume(tobikoPrivateKey, GetConfigMapName(instance, ConfigMapInfixPrivateKey, workflowStepIndex), util.PrivateKeyMode),
+			util.CreateConfigMapVolume(tobikoPublicKey, GetConfigMapName(instance, ConfigMapInfixPublicKey, workflowStepIndex), util.PublicKeyMode),
 		)
 	}
 
@@ -68,7 +91,7 @@ func GetVolumeMounts(
 		util.CreateTestOperatorCloudsConfigVolumeMount("/var/lib/tobiko/.config/openstack/clouds.yaml"),
 		util.CreateTestOperatorCloudsConfigVolumeMount("/etc/openstack/clouds.yaml"),
 		util.CreateOpenstackConfigSecretVolumeMount(instance.Spec.OpenStackConfigSecret, "/etc/openstack/secure.yaml"),
-		util.CreateVolumeMountWithSubPath(tobikoConfig, "/etc/tobiko/tobiko.conf", "tobiko.conf", false),
+		util.CreateVolumeMountWithSubPath(tobikoConfig, "/etc/tobiko/tobiko.conf", ConfigFileName, false),
 	}
 
 	if mountCerts {
@@ -80,8 +103,8 @@ func GetVolumeMounts(
 
 	if mountKeys {
 		volumeMounts = append(volumeMounts,
-			util.CreateVolumeMountWithSubPath(tobikoPrivateKey, "/etc/test_operator/id_ecdsa", "id_ecdsa", true),
-			util.CreateVolumeMountWithSubPath(tobikoPublicKey, "/etc/test_operator/id_ecdsa.pub", "id_ecdsa.pub", true),
+			util.CreateVolumeMountWithSubPath(tobikoPrivateKey, "/etc/test_operator/id_ecdsa", PrivateKeyFileName, true),
+			util.CreateVolumeMountWithSubPath(tobikoPublicKey, "/etc/test_operator/id_ecdsa.pub", PublicKeyFileName, true),
 		)
 	}
 


### PR DESCRIPTION
Tobiko was reusing the same ConfigMap names across all workflow steps, causing later steps to overwrite earlier configs. Now it uses workflow-specific names to ensure each step preserves its own configuration.