### PR TITLE
Add ServiceConfigReadyCondition to Tobiko and HorizonTest

### DIFF
--- a/internal/controller/horizontest_controller.go
+++ b/internal/controller/horizontest_controller.go
@@ -111,6 +111,7 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		cl := condition.CreateList(
 			condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
 			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
 		)
 		instance.Status.Conditions.Init(&cl)
@@ -198,23 +199,6 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{RequeueAfter: RequeueAfterValue}, err
 	}
 
-	yamlResult, err := EnsureCloudsConfigMapExists(
-		ctx,
-		instance,
-		helper,
-		serviceLabels,
-		instance.Spec.OpenStackConfigMap,
-	)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return yamlResult, err
-	}
-
 	err = r.ValidateSecretWithKeys(ctx, instance, instance.Spec.KubeconfigSecretName, []string{})
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -226,8 +210,25 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 	mountKubeconfig := len(instance.Spec.KubeconfigSecretName) != 0
-
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
+
+	yamlResult, err := EnsureCloudsConfigMapExists(
+		ctx,
+		instance,
+		helper,
+		serviceLabels,
+		instance.Spec.OpenStackConfigMap,
+	)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ServiceConfigReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceConfigReadyErrorMessage,
+			err.Error()))
+		return yamlResult, err
+	}
+	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
 	// Create PersistentVolumeClaim
 	ctrlResult, err := r.EnsureLogsPVCExists(

--- a/internal/controller/tobiko_controller.go
+++ b/internal/controller/tobiko_controller.go
@@ -115,6 +115,7 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		cl := condition.CreateList(
 			condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
 			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
 			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
 		)
@@ -438,8 +439,15 @@ func (r *TobikoReconciler) PrepareTobikoEnvVars(
 
 	err := configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)
 	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.ServiceConfigReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.ServiceConfigReadyErrorMessage,
+			err.Error()))
 		return map[string]env.Setter{}
 	}
+	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
 	return envVars
 }

--- a/test/functional/horizontest_controller_test.go
+++ b/test/functional/horizontest_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("HorizonTest controller", func() {
 		It("initializes the status fields", func() {
 			Eventually(func(g Gomega) {
 				horizonTest := GetHorizonTest(horizonTestName)
-				g.Expect(horizonTest.Status.Conditions).To(HaveLen(3))
+				g.Expect(horizonTest.Status.Conditions).To(HaveLen(4))
 				g.Expect(horizonTest.Status.Hash).To(BeEmpty())
 			}, timeout*2, interval).Should(Succeed())
 		})

--- a/test/functional/tobiko_controller_test.go
+++ b/test/functional/tobiko_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Tobiko controller", func() {
 		It("initializes the status fields", func() {
 			Eventually(func(g Gomega) {
 				tobiko := GetTobiko(tobikoName)
-				g.Expect(tobiko.Status.Conditions).To(HaveLen(4))
+				g.Expect(tobiko.Status.Conditions).To(HaveLen(5))
 				g.Expect(tobiko.Status.Hash).To(BeEmpty())
 				g.Expect(tobiko.Status.NetworkAttachments).To(BeEmpty())
 			}, timeout*2, interval).Should(Succeed())


### PR DESCRIPTION
Both Tobiko and HorizonTest controllers create ConfigMaps but were not tracking their state via ServiceConfigReadyCondition. Their addition should help with easier error debugging and match the Tempest pattern.