### PR TITLE
Fix logger and move failure case

### DIFF
--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -31,6 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -489,8 +490,8 @@ func (r *Reconciler) EnsureLogsPVCExists(
 }
 
 // GetLogger returns the logger instance
-func (r *Reconciler) GetLogger() logr.Logger {
-	return r.Log
+func (r *Reconciler) GetLogger(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx)
 }
 
 // GetScheme returns the runtime scheme
@@ -555,7 +556,7 @@ func (r *Reconciler) AcquireLock(
 
 // ReleaseLock releases the lock for the given instance
 func (r *Reconciler) ReleaseLock(ctx context.Context, instance client.Object) (bool, error) {
-	Log := r.GetLogger()
+	Log := r.GetLogger(ctx)
 
 	cm, err := r.GetLockInfo(ctx, instance)
 	if err != nil && k8s_errors.IsNotFound(err) {

--- a/internal/controller/common_controller.go
+++ b/internal/controller/common_controller.go
@@ -180,6 +180,9 @@ func CommonReconcile[T TestResource](
 	}
 
 	nextAction, workflowStepIndex, err := r.NextAction(ctx, instance, workflowLength)
+	if nextAction == Failure {
+		return ctrl.Result{}, err
+	}
 
 	// Apply workflow step overrides to the base spec
 	if config.SupportsWorkflow && workflowStepIndex < workflowLength {
@@ -200,9 +203,6 @@ func CommonReconcile[T TestResource](
 	}
 
 	switch nextAction {
-	case Failure:
-		return ctrl.Result{}, err
-
 	case Wait:
 		Log.Info(InfoWaitingOnPod)
 		return ctrl.Result{RequeueAfter: RequeueAfterValue}, nil


### PR DESCRIPTION
The common logger was not taking context into consideration and therefore it was not printing out logs the same way as other loggers. With this PR the common logger should now print logs correctly.

Additionally, it moves error handling directly after NextAction call instead of deferring it until later in the reconcile flow. This prevents executing unnecessary operations when NextAction has already failed.