### PR TITLE
[tobiko] Add new parameter SkipRegexList

### DIFF
--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -1378,6 +1378,14 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              skipRegexList:
+                description: |-
+                  List of test name patterns to skip. It has the same functionality
+                  as the --skipregex parameter used in PytestAddopts.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
               storageClass:
                 default: local-storage
                 description: StorageClass used to create any test-operator related
@@ -1617,6 +1625,14 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                       type: object
+                    skipRegexList:
+                      description: |-
+                        List of test name patterns to skip. It has the same functionality
+                        as the --skipregex parameter used in PytestAddopts.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     stepName:
                       description: A parameter that contains a definition of a single
                         workflow step.

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -65,6 +65,13 @@ type TobikoSpec struct {
 	PytestAddopts string `json:"pytestAddopts"`
 
 	// +kubebuilder:validation:Optional
+	// +listType=atomic
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// List of test name patterns to skip. It has the same functionality
+	// as the --skipregex parameter used in PytestAddopts.
+	SkipRegexList []string `json:"skipRegexList,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:default:=false
 	// Boolean specifying whether tobiko tests create new resources or re-use those previously created
@@ -150,6 +157,13 @@ type TobikoWorkflowSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// String including any options to pass to pytest when it runs tobiko tests
 	PytestAddopts string `json:"pytestAddopts,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +listType=atomic
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// List of test name patterns to skip. It has the same functionality
+	// as the --skipregex parameter used in PytestAddopts.
+	SkipRegexList []string `json:"skipRegexList,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -637,6 +637,11 @@ func (in *TobikoSpec) DeepCopyInto(out *TobikoSpec) {
 	in.CommonOptions.DeepCopyInto(&out.CommonOptions)
 	out.CommonOpenstackConfig = in.CommonOpenstackConfig
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.SkipRegexList != nil {
+		in, out := &in.SkipRegexList, &out.SkipRegexList
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.Patch = in.Patch
 	if in.NetworkAttachments != nil {
 		in, out := &in.NetworkAttachments, &out.NetworkAttachments
@@ -671,6 +676,11 @@ func (in *TobikoWorkflowSpec) DeepCopyInto(out *TobikoWorkflowSpec) {
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SkipRegexList != nil {
+		in, out := &in.SkipRegexList, &out.SkipRegexList
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.PreventCreate != nil {
 		in, out := &in.PreventCreate, &out.PreventCreate

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -1378,6 +1378,14 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              skipRegexList:
+                description: |-
+                  List of test name patterns to skip. It has the same functionality
+                  as the --skipregex parameter used in PytestAddopts.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
               storageClass:
                 default: local-storage
                 description: StorageClass used to create any test-operator related
@@ -1617,6 +1625,14 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                           type: object
                       type: object
+                    skipRegexList:
+                      description: |-
+                        List of test name patterns to skip. It has the same functionality
+                        as the --skipregex parameter used in PytestAddopts.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     stepName:
                       description: A parameter that contains a definition of a single
                         workflow step.

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -846,6 +846,22 @@ func SetDictEnvVar(envVars map[string]string, fields map[string]string) {
 	}
 }
 
+// PreparePytestAddopts adds skipregex parameter to the PytestAddopts
+func PreparePytestAddopts(pytestAddopts string, skipRegexList []string) string {
+	if len(skipRegexList) == 0 {
+		return pytestAddopts
+	}
+
+	skipRegex := strings.Join(skipRegexList, "|")
+	skipOpt := fmt.Sprintf("--skipregex='%s'", skipRegex)
+
+	if len(pytestAddopts) == 0 {
+		return skipOpt
+	}
+
+	return fmt.Sprintf("%s %s", pytestAddopts, skipOpt)
+}
+
 // GetStringField returns reflect string field safely
 func GetStringField(v reflect.Value, fieldName string) string {
 	field, err := SafetyCheck(v, fieldName)

--- a/internal/controller/tobiko_controller.go
+++ b/internal/controller/tobiko_controller.go
@@ -237,7 +237,7 @@ func (r *TobikoReconciler) PrepareTobikoEnvVars(
 		"TOBIKO_LOGS_DIR_NAME":  r.GetPodName(instance, workflowStepIndex),
 		"TOBIKO_TESTENV":        instance.Spec.Testenv,
 		"TOBIKO_VERSION":        instance.Spec.Version,
-		"TOBIKO_PYTEST_ADDOPTS": instance.Spec.PytestAddopts,
+		"TOBIKO_PYTEST_ADDOPTS": PreparePytestAddopts(instance.Spec.PytestAddopts, instance.Spec.SkipRegexList),
 		"TOBIKO_KEYS_FOLDER":    "/etc/test_operator",
 	})
 


### PR DESCRIPTION
This change introduces a new SkipRegexList parameter to Tobiko. Currently, tests can be skipped by using --skipregex='' parameter in PytestAdopt. However, when having too many entries it becomes cluttered. This parameter helps with keeping the structure readable and user friendly, while keeping the functionality.