### PR TITLE
Remove scaffolding TODOs from v1beta1 webhooks

### DIFF
--- a/internal/webhook/v1beta1/ansibletest_webhook.go
+++ b/internal/webhook/v1beta1/ansibletest_webhook.go
@@ -36,8 +36,7 @@ var (
 	ErrInvalidAnsibleTestType = errors.New("invalid object type for AnsibleTest webhook")
 )
 
-// nolint:unused
-// log is for logging in this package.
+// ansibletestlog is for logging in this package.
 var ansibletestlog = logf.Log.WithName("ansibletest-resource")
 
 // SetupAnsibleTestWebhookWithManager registers the webhook for AnsibleTest in the manager.
@@ -51,17 +50,11 @@ func SetupAnsibleTestWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
 // +kubebuilder:webhook:path=/mutate-test-openstack-org-v1beta1-ansibletest,mutating=true,failurePolicy=fail,sideEffects=None,groups=test.openstack.org,resources=ansibletests,verbs=create;update,versions=v1beta1,name=mansibletest-v1beta1.kb.io,admissionReviewVersions=v1
 
 // AnsibleTestCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind AnsibleTest when those are created or updated.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as it is used only for temporary operations and does not need to be deeply copied.
 type AnsibleTestCustomDefaulter struct {
-	// TODO(user): Add more fields as needed for defaulting
 }
 
 var _ webhook.CustomDefaulter = &AnsibleTestCustomDefaulter{}
@@ -81,18 +74,11 @@ func (d *AnsibleTestCustomDefaulter) Default(_ context.Context, obj runtime.Obje
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
-// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 // +kubebuilder:webhook:path=/validate-test-openstack-org-v1beta1-ansibletest,mutating=false,failurePolicy=fail,sideEffects=None,groups=test.openstack.org,resources=ansibletests,verbs=create;update,versions=v1beta1,name=vansibletest-v1beta1.kb.io,admissionReviewVersions=v1
 
 // AnsibleTestCustomValidator struct is responsible for validating the AnsibleTest resource
 // when it is created, updated, or deleted.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as this struct is used only for temporary operations and does not need to be deeply copied.
 type AnsibleTestCustomValidator struct {
-	// TODO(user): Add more fields as needed for validation
 }
 
 var _ webhook.CustomValidator = &AnsibleTestCustomValidator{}

--- a/internal/webhook/v1beta1/horizontest_webhook.go
+++ b/internal/webhook/v1beta1/horizontest_webhook.go
@@ -35,8 +35,7 @@ var (
 	ErrInvalidHorizonTestType = errors.New("invalid object type for HorizonTest webhook")
 )
 
-// nolint:unused
-// log is for logging in this package.
+// horizontestlog is for logging in this package.
 var horizontestlog = logf.Log.WithName("horizontest-resource")
 
 // SetupHorizonTestWebhookWithManager registers the webhook for HorizonTest in the manager.
@@ -50,17 +49,11 @@ func SetupHorizonTestWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
 // +kubebuilder:webhook:path=/mutate-test-openstack-org-v1beta1-horizontest,mutating=true,failurePolicy=fail,sideEffects=None,groups=test.openstack.org,resources=horizontests,verbs=create;update,versions=v1beta1,name=mhorizontest-v1beta1.kb.io,admissionReviewVersions=v1
 
 // HorizonTestCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind HorizonTest when those are created or updated.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as it is used only for temporary operations and does not need to be deeply copied.
 type HorizonTestCustomDefaulter struct {
-	// TODO(user): Add more fields as needed for defaulting
 }
 
 var _ webhook.CustomDefaulter = &HorizonTestCustomDefaulter{}
@@ -80,18 +73,11 @@ func (d *HorizonTestCustomDefaulter) Default(_ context.Context, obj runtime.Obje
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
-// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 // +kubebuilder:webhook:path=/validate-test-openstack-org-v1beta1-horizontest,mutating=false,failurePolicy=fail,sideEffects=None,groups=test.openstack.org,resources=horizontests,verbs=create;update,versions=v1beta1,name=vhorizontest-v1beta1.kb.io,admissionReviewVersions=v1
 
 // HorizonTestCustomValidator struct is responsible for validating the HorizonTest resource
 // when it is created, updated, or deleted.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as this struct is used only for temporary operations and does not need to be deeply copied.
 type HorizonTestCustomValidator struct {
-	// TODO(user): Add more fields as needed for validation
 }
 
 var _ webhook.CustomValidator = &HorizonTestCustomValidator{}

--- a/internal/webhook/v1beta1/tempest_webhook.go
+++ b/internal/webhook/v1beta1/tempest_webhook.go
@@ -35,8 +35,7 @@ var (
 	ErrInvalidTempestType = errors.New("invalid object type for Tempest webhook")
 )
 
-// nolint:unused
-// log is for logging in this package.
+// tempestlog is for logging in this package.
 var tempestlog = logf.Log.WithName("tempest-resource")
 
 // SetupTempestWebhookWithManager registers the webhook for Tempest in the manager.
@@ -50,17 +49,11 @@ func SetupTempestWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
 // +kubebuilder:webhook:path=/mutate-test-openstack-org-v1beta1-tempest,mutating=true,failurePolicy=fail,sideEffects=None,groups=test.openstack.org,resources=tempests,verbs=create;update,versions=v1beta1,name=mtempest-v1beta1.kb.io,admissionReviewVersions=v1
 
 // TempestCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Tempest when those are created or updated.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as it is used only for temporary operations and does not need to be deeply copied.
 type TempestCustomDefaulter struct {
-	// TODO(user): Add more fields as needed for defaulting
 }
 
 var _ webhook.CustomDefaulter = &TempestCustomDefaulter{}
@@ -80,18 +73,11 @@ func (d *TempestCustomDefaulter) Default(_ context.Context, obj runtime.Object) 
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
-// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 // +kubebuilder:webhook:path=/validate-test-openstack-org-v1beta1-tempest,mutating=false,failurePolicy=fail,sideEffects=None,groups=test.openstack.org,resources=tempests,verbs=create;update,versions=v1beta1,name=vtempest-v1beta1.kb.io,admissionReviewVersions=v1
 
 // TempestCustomValidator struct is responsible for validating the Tempest resource
 // when it is created, updated, or deleted.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as this struct is used only for temporary operations and does not need to be deeply copied.
 type TempestCustomValidator struct {
-	// TODO(user): Add more fields as needed for validation
 }
 
 var _ webhook.CustomValidator = &TempestCustomValidator{}

--- a/internal/webhook/v1beta1/tobiko_webhook.go
+++ b/internal/webhook/v1beta1/tobiko_webhook.go
@@ -35,8 +35,7 @@ var (
 	ErrInvalidTobikoType = errors.New("invalid object type for Tobiko webhook")
 )
 
-// nolint:unused
-// log is for logging in this package.
+// tobikolog is for logging in this package.
 var tobikolog = logf.Log.WithName("tobiko-resource")
 
 // SetupTobikoWebhookWithManager registers the webhook for Tobiko in the manager.
@@ -50,17 +49,11 @@ func SetupTobikoWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
 // +kubebuilder:webhook:path=/mutate-test-openstack-org-v1beta1-tobiko,mutating=true,failurePolicy=fail,sideEffects=None,groups=test.openstack.org,resources=tobikoes,verbs=create;update,versions=v1beta1,name=mtobiko-v1beta1.kb.io,admissionReviewVersions=v1
 
 // TobikoCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Tobiko when those are created or updated.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as it is used only for temporary operations and does not need to be deeply copied.
 type TobikoCustomDefaulter struct {
-	// TODO(user): Add more fields as needed for defaulting
 }
 
 var _ webhook.CustomDefaulter = &TobikoCustomDefaulter{}
@@ -80,18 +73,11 @@ func (d *TobikoCustomDefaulter) Default(_ context.Context, obj runtime.Object) e
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
-// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 // +kubebuilder:webhook:path=/validate-test-openstack-org-v1beta1-tobiko,mutating=false,failurePolicy=fail,sideEffects=None,groups=test.openstack.org,resources=tobikoes,verbs=create;update,versions=v1beta1,name=vtobiko-v1beta1.kb.io,admissionReviewVersions=v1
 
 // TobikoCustomValidator struct is responsible for validating the Tobiko resource
 // when it is created, updated, or deleted.
-//
-// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
-// as this struct is used only for temporary operations and does not need to be deeply copied.
 type TobikoCustomValidator struct {
-	// TODO(user): Add more fields as needed for validation
 }
 
 var _ webhook.CustomValidator = &TobikoCustomValidator{}


### PR DESCRIPTION
This PR Cleans up the v1beta1 webhook package comments (AnsibleTest, HorizonTest, Tempest, Tobiko) autogenerated

Type: Code hygiene (no functional change)

Description

> Remove comments in internal/webhook/v1beta1/*_webhook.go  files
> Kept +kubebuilder:webhook: markers  and function / method descriptors unchanged so controller-gen and generated manifests keep intended expected behaviour

No logic changes; run existing unit/functional tests and linters as usual.