### PR TITLE
Add Type field to util.Template structs

### DIFF
--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -545,6 +545,7 @@ func (r *Reconciler) AcquireLock(
 			{
 				Name:       testOperatorLockName,
 				Namespace:  instance.GetNamespace(),
+				Type:       util.TemplateTypeNone,
 				CustomData: cm,
 			},
 		}
@@ -780,6 +781,7 @@ func EnsureCloudsConfigMapExists(
 		{
 			Name:      testOperatorCloudsConfigMapName,
 			Namespace: instance.GetNamespace(),
+			Type:      util.TemplateTypeNone,
 			Labels:    labels,
 			CustomData: map[string]string{
 				"clouds.yaml": string(yamlString),

--- a/internal/controller/tempest_controller.go
+++ b/internal/controller/tempest_controller.go
@@ -325,6 +325,7 @@ func (r *TempestReconciler) generateServiceConfigMaps(
 		{
 			Name:          GetCustomDataConfigMapName(instance, workflowStepIndex),
 			Namespace:     instance.Namespace,
+			Type:          util.TemplateTypeNone,
 			InstanceType:  instance.Kind,
 			Labels:        cmLabels,
 			ConfigOptions: templateParameters,
@@ -334,6 +335,7 @@ func (r *TempestReconciler) generateServiceConfigMaps(
 		{
 			Name:          GetEnvVarsConfigMapName(instance, workflowStepIndex),
 			Namespace:     instance.Namespace,
+			Type:          util.TemplateTypeNone,
 			InstanceType:  instance.Kind,
 			Labels:        cmLabels,
 			ConfigOptions: templateParameters,

--- a/internal/controller/tobiko_controller.go
+++ b/internal/controller/tobiko_controller.go
@@ -201,6 +201,7 @@ func (r *TobikoReconciler) generateServiceConfigMaps(
 		cms = append(cms, util.Template{
 			Name:         tobiko.GetConfigMapName(instance, spec.infix, workflowStepIndex),
 			Namespace:    instance.Namespace,
+			Type:         util.TemplateTypeNone,
 			InstanceType: instance.Kind,
 			Labels:       labels,
 			CustomData:   map[string]string{spec.key: spec.value},


### PR DESCRIPTION
The updated lib-common dependency now requires the Type field to be set when creating configmaps via util.Template. Set all instances to TemplateTypeNone to fix functional test failures.