### PR TITLE
Add parameter for HorizonTest

### DIFF
--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -1325,6 +1325,12 @@ spec:
                   ProjectNameXpath is the xpath to select project name
                   on the horizon dashboard based on the u/s or d/s theme
                 type: string
+              projectTextXpath:
+                description: |-
+                  ProjectTextXpath is the xpath to element displaying
+                  current project name on the horizon dashboard based
+                  on the u/s or d/s theme
+                type: string
               repoUrl:
                 default: https://review.opendev.org/openstack/horizon
                 description: RepoUrl is the URL of the Horizon repository.

--- a/api/v1beta1/horizontest_types.go
+++ b/api/v1beta1/horizontest_types.go
@@ -52,6 +52,13 @@ type HorizonTestSpec struct {
 	// on the horizon dashboard based on the u/s or d/s theme
 	ProjectNameXpath string `json:"projectNameXpath"`
 
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// ProjectTextXpath is the xpath to element displaying
+	// current project name on the horizon dashboard based
+	// on the u/s or d/s theme
+	ProjectTextXpath string `json:"projectTextXpath"`
+
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -1325,6 +1325,12 @@ spec:
                   ProjectNameXpath is the xpath to select project name
                   on the horizon dashboard based on the u/s or d/s theme
                 type: string
+              projectTextXpath:
+                description: |-
+                  ProjectTextXpath is the xpath to element displaying
+                  current project name on the horizon dashboard based
+                  on the u/s or d/s theme
+                type: string
               repoUrl:
                 default: https://review.opendev.org/openstack/horizon
                 description: RepoUrl is the URL of the Horizon repository.

--- a/config/samples/test_v1beta1_horizontest.yaml
+++ b/config/samples/test_v1beta1_horizontest.yaml
@@ -62,6 +62,9 @@ spec:
   # ProjectNameXpath is the xpath to select project name on dashboard (optional)
   projectNameXpath: "//span[@class='rcueicon rcueicon-folder-open']/ancestor::li"
 
+  # ProjectTextXpath is the xpath to element displaying current project (optional)
+  projectTextXpath: ".//span[@class='rcueicon rcueicon-folder-open']/ancestor::li"
+
   # Privileged
   # ----------
   #

--- a/internal/controller/horizontest_controller.go
+++ b/internal/controller/horizontest_controller.go
@@ -187,6 +187,7 @@ func (r *HorizonTestReconciler) PrepareHorizonTestEnvVars(
 		"HORIZON_KEYS_FOLDER": "/etc/test_operator",
 		"EXTRA_FLAG":          instance.Spec.ExtraFlag,
 		"PROJECT_NAME_XPATH":  instance.Spec.ProjectNameXpath,
+		"PROJECT_TEXT_XPATH":  instance.Spec.ProjectTextXpath,
 	})
 
 	return envVars

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -127,6 +127,7 @@
       cifmw_test_operator_horizontest_dashboard_url: "https://horizon-openstack.apps-crc.testing/"
       cifmw_test_operator_horizontest_extra_flag: "not pagination and test_users.py"
       cifmw_test_operator_horizontest_project_name_xpath: //*[@class="context-project"]//ancestor::ul
+      cifmw_test_operator_horizontest_project_text_xpath: './/*[@class="context-project"]'
       cifmw_test_operator_horizontest_extra_mounts:
         - name: v1
           region: r1


### PR DESCRIPTION
This PR adds additional parameter to horizontest CR in order to modify projecttext xpath based on
upstream and downstream dashboard theme.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3897