### PR TITLE
[tobiko] Use pytestAddopts for test path

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -100,7 +100,8 @@
       # Tobiko
       cifmw_test_operator_tobiko_workflow:
         - stepName: 'podified-functional'
-          testenv: 'functional -- tobiko/tests/functional/podified/test_topology.py'
+          testenv: 'functional'
+          pytestAddopts: "tobiko/tests/functional/podified/test_topology.py"
           numProcesses: 2
         - stepName: 'sanity'
           testenv: 'sanity'


### PR DESCRIPTION
Split testenv and test path using pytestAddopts field to avoid YAML quoting problems with the '--' separator. This is temporary until the quoting issue is resolved.