### PR TITLE
Update owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,10 +7,12 @@ aliases:
   - stuggi
   test-approvers:
   - lpiwowar
+  - adrianfusco
   - arxcruz
   - kstrenkova
   test-reviewers:
   - evallesp
-  - frenzyfriday
-  - sdatko
-  - adrianfusco
+  - rebtoor
+  - Valkyrie00
+  - imatza-rh
+  - posikoya


### PR DESCRIPTION
This change removes users that are not part of openstack anymore and adds more people from the ciops team who are able to review and approve new PRs.