### PR TITLE
Fix kuttl cleanup timeout

### DIFF
--- a/test/kuttl/common/cleanup-all-tests.yaml
+++ b/test/kuttl/common/cleanup-all-tests.yaml
@@ -1,12 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
-- apiVersion: v1
-  kind: ConfigMap
-  name: openstack-config
-- apiVersion: v1
-  kind: Secret
-  name: openstack-config-secret
 - apiVersion: test.openstack.org/v1beta1
   kind: Tempest
   name: tempest-sample

--- a/test/kuttl/common/errors-cleanup.yaml
+++ b/test/kuttl/common/errors-cleanup.yaml
@@ -2,20 +2,13 @@
 # Check for:
 #
 # No CRs
-# No Pods
-# No ConfigMaps
-# No Secrets
+# No Pods owned by test-operator
 #
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: openstack-config
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: openstack-config-secret
----
+# NOTE: openstack-config ConfigMap and openstack-config-secret Secret are
+# infrastructure resources managed by the CI environment (not by the
+# test-operator) and must NOT be checked here. Other operators in the
+# namespace may recreate them after deletion, causing cleanup timeouts.
+#
 apiVersion: test.openstack.org/v1beta1
 kind: Tempest
 metadata:
@@ -40,22 +33,22 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    job-name: tempest-sample
+    instanceName: tempest-sample
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    job-name: tobiko-sample
+    instanceName: tobiko-sample
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    job-name: ansibletest-sample
+    instanceName: ansibletest-sample
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    job-name: horizontest-sample
+    instanceName: horizontest-sample


### PR DESCRIPTION
## Problem

The `tempest-basic` kuttl test fails with `context deadline exceeded` during the `99-cleanup` step after waiting 600 seconds.

The shared `errors-cleanup.yaml` asserted the absence of `openstack-config` ConfigMap and `openstack-config-secret` Secret. These are **infrastructure resources** deployed by `install_yamls` for the CI environment. They are not
created or managed by the test-operator. Other operators running in the `test-operator-kuttl-tests` namespace (keystone, galera, rabbitmq, memcached) keep these resources alive, so they persist after deletion and the error check never passes.

Additionally, the Pod checks in `errors-cleanup.yaml` used `job-name` as the label selector, but the test-operator labels its pods with `instanceName` (see `internal/controller/common.go`). The old selector never matched any test-operator pods, making the check a no-op.

## Fix Proposal

- Remove `openstack-config` ConfigMap and `openstack-config-secret` Secret   from both `cleanup-all-tests.yaml` (delete step) and `errors-cleanup.yaml` The cleanup now only targets test-operator CRs.
- Fix Pod label selectors from `job-name` to `instanceName` so the absence  check actually matches pods created by the test-operator.

Assisted-By: Cursor
Relevance: #417 #452