### PR TITLE
add envtests for extraMounts feature

### DIFF
--- a/test/functional/ansibletest_controller_test.go
+++ b/test/functional/ansibletest_controller_test.go
@@ -116,4 +116,112 @@ var _ = Describe("AnsibleTest controller", func() {
 			Expect(pod.Name).ToNot(BeEmpty())
 		})
 	})
+
+	Context("extraMounts", func() {
+		BeforeEach(func() {
+			openstackConfigMap, openstackSecret := CreateCommonOpenstackResources(namespace)
+			Expect(k8sClient.Create(ctx, openstackConfigMap)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, openstackSecret)).Should(Succeed())
+
+			testOperatorConfigMap := CreateTestOperatorConfigMap(namespace)
+			Expect(k8sClient.Create(ctx, testOperatorConfigMap)).Should(Succeed())
+		})
+
+		When("AnsibleTest is created with extraMounts", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultAnsibleTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("AnsibleTest",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateAnsibleTest(ansibleTestName, spec))
+			})
+
+			It("should add extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, ansibleTestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+			})
+		})
+
+		When("AnsibleTest is created with Secret as the source of extraMount", func() {
+			BeforeEach(func() {
+				CreateExtraSecret(namespace, ExtraSecretName)
+
+				spec := GetDefaultAnsibleTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("AnsibleTest",
+					GetDefaultSecretExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateAnsibleTest(ansibleTestName, spec))
+			})
+
+			It("should add secret based extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, ansibleTestName.Name)
+				ExpectPodHasSecretVolume(pod, ExtraSecretVolName, ExtraSecretName)
+				ExpectPodHasVolumeMount(pod, ExtraSecretVolName, ExtraSecretMountPath)
+			})
+		})
+
+		When("AnsibleTest is created with multiple extraMounts configmap and secret", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+				CreateExtraSecret(namespace, ExtraSecretName)
+
+				spec := GetDefaultAnsibleTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("AnsibleTest",
+					GetDefaultConfigMapExtraMount(),
+					GetDefaultSecretExtraMount(),
+				)
+
+				DeferCleanup(th.DeleteInstance, CreateAnsibleTest(ansibleTestName, spec))
+			})
+
+			It("should add all extra volumes and volumeMounts to the pod", func() {
+				pod := GetTestOperatorPod(namespace, ansibleTestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasSecretVolume(pod, ExtraSecretVolName, ExtraSecretName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+				ExpectPodHasVolumeMount(pod, ExtraSecretVolName, ExtraSecretMountPath)
+			})
+		})
+
+		When("AnsibleTest is created with no propagation field", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultAnsibleTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateAnsibleTest(ansibleTestName, spec))
+			})
+
+			It("should add extra volume and volumeMount when propagation is omitted", func() {
+				pod := GetTestOperatorPod(namespace, ansibleTestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+			})
+		})
+
+		When("AnsibleTest created with extraMounts is using the wrong propagation type", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultAnsibleTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("Tempest",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateAnsibleTest(ansibleTestName, spec))
+			})
+
+			It("should not add extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, ansibleTestName.Name)
+				ExpectPodNotHasVolume(pod, ExtraConfigVolName)
+				ExpectPodNotHasVolumeMount(pod, ExtraConfigVolName)
+			})
+		})
+
+	})
+
 })

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -36,7 +36,20 @@ const (
 	DefaultStorageClass         = "local-storage"
 	DefaultComputeSSHKeySecret  = "dataplane-ansible-ssh-private-key-secret" // #nosec G101
 	DefaultWorkloadSSHKeySecret = "dataplane-ansible-ssh-private-key-secret" // #nosec G101
+	ExtraConfigMapName          = "extra-config"
+	ExtraConfigVolName          = "extra-config-vol"
+	ExtraConfigMountPath        = "/etc/extra-config"
+	ExtraSecretName             = "extra-secret"      // #nosec G101
+	ExtraSecretVolName          = "extra-secret-vol"  // #nosec G101
+	ExtraSecretMountPath        = "/etc/extra-secret" // #nosec G101
 )
+
+type ExtraMount struct {
+	VolName    string
+	SourceName string // ConfigMap or Secret name
+	MountPath  string
+	IsSecret   bool
+}
 
 func CreateUnstructured(rawObj map[string]any) *unstructured.Unstructured {
 	logger.Info("Creating", "raw", rawObj)
@@ -84,6 +97,136 @@ func CreateTestOperatorConfigMap(namespace string) *corev1.ConfigMap {
 			"tempest-image":     "quay.io/podified-antelope-centos9/openstack-tempest:current-podified",
 			"tobiko-image":      "quay.io/podified-antelope-centos9/openstack-tobiko:current-podified",
 		},
+	}
+}
+
+func CreateExtraConfigMap(namespace string, name string) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"config.conf": "key=value",
+		},
+	}
+	Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
+}
+
+func CreateExtraSecret(namespace string, name string) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		StringData: map[string]string{
+			"secret.conf": "key=value",
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+}
+
+func BuildExtraMountsSpec(propagation string, mounts ...ExtraMount) []map[string]any {
+	volumes := []map[string]any{}
+	volumeMounts := []map[string]any{}
+
+	for _, m := range mounts {
+		vol := map[string]any{"name": m.VolName}
+		if m.IsSecret {
+			vol["secret"] = map[string]any{"secretName": m.SourceName}
+		} else {
+			vol["configMap"] = map[string]any{"name": m.SourceName}
+		}
+		volumes = append(volumes, vol)
+
+		volumeMounts = append(volumeMounts, map[string]any{
+			"name":      m.VolName,
+			"mountPath": m.MountPath,
+			"readOnly":  true,
+		})
+	}
+
+	extraVol := map[string]any{
+		"volumes": volumes,
+		"mounts":  volumeMounts,
+	}
+	if propagation != "" {
+		extraVol["propagation"] = []string{propagation}
+	}
+	return []map[string]any{
+		{"extraVol": []map[string]any{extraVol}},
+	}
+}
+
+func ExpectPodHasConfigMapVolume(pod *corev1.Pod, volName string, cmName string) {
+	foundVolume := false
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == volName {
+			foundVolume = true
+			Expect(vol.VolumeSource.ConfigMap).NotTo(BeNil())
+			Expect(vol.VolumeSource.ConfigMap.Name).To(Equal(cmName))
+			break
+		}
+	}
+	Expect(foundVolume).To(BeTrue(), "expected pod to have volume '%s'", volName)
+}
+
+func ExpectPodHasSecretVolume(pod *corev1.Pod, volName string, secretName string) {
+	foundVolume := false
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == volName {
+			foundVolume = true
+			Expect(vol.VolumeSource.Secret).NotTo(BeNil())
+			Expect(vol.VolumeSource.Secret.SecretName).To(Equal(secretName))
+			break
+		}
+	}
+	Expect(foundVolume).To(BeTrue(), "expected pod to have volume '%s'", volName)
+}
+
+func ExpectPodHasVolumeMount(pod *corev1.Pod, volName string, mountPath string) {
+	container := pod.Spec.Containers[0]
+	foundMount := false
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == volName {
+			foundMount = true
+			Expect(mount.MountPath).To(Equal(mountPath))
+			Expect(mount.ReadOnly).To(BeTrue())
+			break
+		}
+	}
+	Expect(foundMount).To(BeTrue(), "expected container to have volumeMount '%s'", volName)
+}
+
+func ExpectPodNotHasVolume(pod *corev1.Pod, volName string) {
+	for _, vol := range pod.Spec.Volumes {
+		Expect(vol.Name).NotTo(Equal(volName),
+			"volume should not be propagated with wrong propagation type")
+	}
+}
+
+func ExpectPodNotHasVolumeMount(pod *corev1.Pod, volName string) {
+	container := pod.Spec.Containers[0]
+	for _, mount := range container.VolumeMounts {
+		Expect(mount.Name).NotTo(Equal(volName),
+			"volumeMount should not be propagated with wrong propagation type")
+	}
+}
+
+func GetDefaultConfigMapExtraMount() ExtraMount {
+	return ExtraMount{
+		VolName:    ExtraConfigVolName,
+		SourceName: ExtraConfigMapName,
+		MountPath:  ExtraConfigMountPath,
+	}
+}
+
+func GetDefaultSecretExtraMount() ExtraMount {
+	return ExtraMount{
+		VolName:    ExtraSecretVolName,
+		SourceName: ExtraSecretName,
+		MountPath:  ExtraSecretMountPath,
+		IsSecret:   true,
 	}
 }
 

--- a/test/functional/horizontest_controller_test.go
+++ b/test/functional/horizontest_controller_test.go
@@ -118,4 +118,111 @@ var _ = Describe("HorizonTest controller", func() {
 			Expect(pod.Name).ToNot(BeEmpty())
 		})
 	})
+
+	Context("extraMounts", func() {
+		BeforeEach(func() {
+			openstackConfigMap, openstackSecret := CreateCommonOpenstackResources(namespace)
+			Expect(k8sClient.Create(ctx, openstackConfigMap)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, openstackSecret)).Should(Succeed())
+
+			testOperatorConfigMap := CreateTestOperatorConfigMap(namespace)
+			Expect(k8sClient.Create(ctx, testOperatorConfigMap)).Should(Succeed())
+		})
+
+		When("HorizonTest is created with extraMounts", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultHorizonTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("HorizonTest",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateHorizonTest(horizonTestName, spec))
+			})
+
+			It("should add extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, horizonTestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+			})
+		})
+
+		When("HorizonTest is created with Secret as the source of extraMount", func() {
+			BeforeEach(func() {
+				CreateExtraSecret(namespace, ExtraSecretName)
+
+				spec := GetDefaultHorizonTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("HorizonTest",
+					GetDefaultSecretExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateHorizonTest(horizonTestName, spec))
+			})
+
+			It("should add secret based extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, horizonTestName.Name)
+				ExpectPodHasSecretVolume(pod, ExtraSecretVolName, ExtraSecretName)
+				ExpectPodHasVolumeMount(pod, ExtraSecretVolName, ExtraSecretMountPath)
+			})
+		})
+
+		When("HorizonTest is created with multiple extraMounts configmap and secret", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+				CreateExtraSecret(namespace, ExtraSecretName)
+
+				spec := GetDefaultHorizonTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("HorizonTest",
+					GetDefaultConfigMapExtraMount(),
+					GetDefaultSecretExtraMount(),
+				)
+
+				DeferCleanup(th.DeleteInstance, CreateHorizonTest(horizonTestName, spec))
+			})
+
+			It("should add all extra volumes and volumeMounts to the pod", func() {
+				pod := GetTestOperatorPod(namespace, horizonTestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasSecretVolume(pod, ExtraSecretVolName, ExtraSecretName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+				ExpectPodHasVolumeMount(pod, ExtraSecretVolName, ExtraSecretMountPath)
+			})
+		})
+
+		When("HorizonTest is created with no propagation field", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultHorizonTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateHorizonTest(horizonTestName, spec))
+			})
+
+			It("should add extra volume and volumeMount when propagation is omitted", func() {
+				pod := GetTestOperatorPod(namespace, horizonTestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+			})
+		})
+
+		When("HorizonTest created with extraMounts is using the wrong propagation type", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultHorizonTestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("Tempest",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateHorizonTest(horizonTestName, spec))
+			})
+
+			It("should not add extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, horizonTestName.Name)
+				ExpectPodNotHasVolume(pod, ExtraConfigVolName)
+				ExpectPodNotHasVolumeMount(pod, ExtraConfigVolName)
+			})
+		})
+	})
+
 })

--- a/test/functional/tempest_controller_test.go
+++ b/test/functional/tempest_controller_test.go
@@ -189,4 +189,110 @@ var _ = Describe("Tempest controller", func() {
 			)
 		})
 	})
+
+	Context("extraMounts", func() {
+		BeforeEach(func() {
+			openstackConfigMap, openstackSecret := CreateCommonOpenstackResources(namespace)
+			Expect(k8sClient.Create(ctx, openstackConfigMap)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, openstackSecret)).Should(Succeed())
+
+			testOperatorConfigMap := CreateTestOperatorConfigMap(namespace)
+			Expect(k8sClient.Create(ctx, testOperatorConfigMap)).Should(Succeed())
+		})
+
+		When("Tempest is created with extraMounts", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultTempestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("Tempest",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateTempest(tempestName, spec))
+			})
+
+			It("should add extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, tempestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+			})
+		})
+
+		When("Tempest is created with Secret as the source of extraMount", func() {
+			BeforeEach(func() {
+				CreateExtraSecret(namespace, ExtraSecretName)
+
+				spec := GetDefaultTempestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("Tempest",
+					GetDefaultSecretExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateTempest(tempestName, spec))
+			})
+
+			It("should add secret based extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, tempestName.Name)
+				ExpectPodHasSecretVolume(pod, ExtraSecretVolName, ExtraSecretName)
+				ExpectPodHasVolumeMount(pod, ExtraSecretVolName, ExtraSecretMountPath)
+			})
+		})
+
+		When("Tempest is created with multiple extraMounts configmap and secret", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+				CreateExtraSecret(namespace, ExtraSecretName)
+
+				spec := GetDefaultTempestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("Tempest",
+					GetDefaultConfigMapExtraMount(),
+					GetDefaultSecretExtraMount(),
+				)
+
+				DeferCleanup(th.DeleteInstance, CreateTempest(tempestName, spec))
+			})
+
+			It("should add all extra volumes and volumeMounts to the pod", func() {
+				pod := GetTestOperatorPod(namespace, tempestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasSecretVolume(pod, ExtraSecretVolName, ExtraSecretName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+				ExpectPodHasVolumeMount(pod, ExtraSecretVolName, ExtraSecretMountPath)
+			})
+		})
+
+		When("Tempest is created with no propagation field", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultTempestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateTempest(tempestName, spec))
+			})
+
+			It("should add extra volume and volumeMount when propagation is omitted", func() {
+				pod := GetTestOperatorPod(namespace, tempestName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+			})
+		})
+
+		When("Tempest created with extraMounts is using the wrong propagation type", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultTempestSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("HorizonTest",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateTempest(tempestName, spec))
+			})
+
+			It("should not add extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, tempestName.Name)
+				ExpectPodNotHasVolume(pod, ExtraConfigVolName)
+				ExpectPodNotHasVolumeMount(pod, ExtraConfigVolName)
+			})
+		})
+	})
 })

--- a/test/functional/tobiko_controller_test.go
+++ b/test/functional/tobiko_controller_test.go
@@ -169,4 +169,110 @@ var _ = Describe("Tobiko controller", func() {
 			)
 		})
 	})
+
+	Context("extraMounts", func() {
+		BeforeEach(func() {
+			openstackConfigMap, openstackSecret := CreateCommonOpenstackResources(namespace)
+			Expect(k8sClient.Create(ctx, openstackConfigMap)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, openstackSecret)).Should(Succeed())
+
+			testOperatorConfigMap := CreateTestOperatorConfigMap(namespace)
+			Expect(k8sClient.Create(ctx, testOperatorConfigMap)).Should(Succeed())
+		})
+
+		When("Tobiko is created with extraMounts", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultTobikoSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("Tobiko",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateTobiko(tobikoName, spec))
+			})
+
+			It("should add extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, tobikoName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+			})
+		})
+
+		When("Tobiko is created with Secret as the source of extraMount", func() {
+			BeforeEach(func() {
+				CreateExtraSecret(namespace, ExtraSecretName)
+
+				spec := GetDefaultTobikoSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("Tobiko",
+					GetDefaultSecretExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateTobiko(tobikoName, spec))
+			})
+
+			It("should add secret based extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, tobikoName.Name)
+				ExpectPodHasSecretVolume(pod, ExtraSecretVolName, ExtraSecretName)
+				ExpectPodHasVolumeMount(pod, ExtraSecretVolName, ExtraSecretMountPath)
+			})
+		})
+
+		When("Tobiko is created with multiple extraMounts configmap and secret", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+				CreateExtraSecret(namespace, ExtraSecretName)
+
+				spec := GetDefaultTobikoSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("Tobiko",
+					GetDefaultConfigMapExtraMount(),
+					GetDefaultSecretExtraMount(),
+				)
+
+				DeferCleanup(th.DeleteInstance, CreateTobiko(tobikoName, spec))
+			})
+
+			It("should add all extra volumes and volumeMounts to the pod", func() {
+				pod := GetTestOperatorPod(namespace, tobikoName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasSecretVolume(pod, ExtraSecretVolName, ExtraSecretName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+				ExpectPodHasVolumeMount(pod, ExtraSecretVolName, ExtraSecretMountPath)
+			})
+		})
+
+		When("Tobiko is created with no propagation field", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultTobikoSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateTobiko(tobikoName, spec))
+			})
+
+			It("should add extra volume and volumeMount when propagation is omitted", func() {
+				pod := GetTestOperatorPod(namespace, tobikoName.Name)
+				ExpectPodHasConfigMapVolume(pod, ExtraConfigVolName, ExtraConfigMapName)
+				ExpectPodHasVolumeMount(pod, ExtraConfigVolName, ExtraConfigMountPath)
+			})
+		})
+
+		When("Tobiko created with extraMounts is using the wrong propagation type", func() {
+			BeforeEach(func() {
+				CreateExtraConfigMap(namespace, ExtraConfigMapName)
+
+				spec := GetDefaultTobikoSpec()
+				spec["extraMounts"] = BuildExtraMountsSpec("HorizonTest",
+					GetDefaultConfigMapExtraMount())
+
+				DeferCleanup(th.DeleteInstance, CreateTobiko(tobikoName, spec))
+			})
+
+			It("should not add extra volume and volumeMount to the pod", func() {
+				pod := GetTestOperatorPod(namespace, tobikoName.Name)
+				ExpectPodNotHasVolume(pod, ExtraConfigVolName)
+				ExpectPodNotHasVolumeMount(pod, ExtraConfigVolName)
+			})
+		})
+	})
 })


### PR DESCRIPTION
The extraMounts feature allows mounting additional volumes (ConfigMaps, Secrets, PVCs) into test pods via propagation filtering.

Add extraMounts envtests for all four controllers (AnsibleTest, Tempest, Tobiko, HorizonTest) that verify the reconciler correctly propagates extra volumes and volumeMounts to the pod spec.i