### PR TITLE
Remove tj-actions/branch-names from build workflow

### DIFF
--- a/.github/workflows/build-test-operator.yaml
+++ b/.github/workflows/build-test-operator.yaml
@@ -32,14 +32,12 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v9
-
     - name: Set latest tag for non main branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
+      if: github.ref_name != 'main'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+        echo "latesttag=${BRANCH_NAME}-latest" >> $GITHUB_ENV
 
     - name: Buildah Action
       id: build-test-operator
@@ -106,14 +104,12 @@ jobs:
         BASE_IMAGE: test-operator
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v9
-
     - name: Set latest tag for non main branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
+      if: github.ref_name != 'main'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+        echo "latesttag=${BRANCH_NAME}-latest" >> $GITHUB_ENV
 
     - name: Build test-operator-bundle using buildah
       id: build-test-operator-bundle
@@ -143,14 +139,12 @@ jobs:
     - name: Checkout test-operator repository
       uses: actions/checkout@v6
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v9
-
     - name: Set latest tag for non main branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
+      if: github.ref_name != 'main'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
+        echo "latesttag=${BRANCH_NAME}-latest" >> $GITHUB_ENV
 
     - name: Install opm
       uses: redhat-actions/openshift-tools-installer@v1


### PR DESCRIPTION
Replace tj-actions/branch-names with github.ref_name which provides the branch name natively without a third-party action. The tj-actions GitHub namespace was compromised in March 2025 (CVE-2025-30066) and using actions from that namespace is no longer recommended. Pass the value via env: to avoid shell interpolation of untrusted input in run: blocks.

Jira: [OSPRH-31654](https://redhat.atlassian.net/browse/OSPRH-31654)