### PR TITLE
Set ImagePullPolicy to IfNotPresent on test pods

### DIFF
--- a/internal/util/common.go
+++ b/internal/util/common.go
@@ -117,6 +117,7 @@ func BuildTestPod(
 				{
 					Name:            containerName,
 					Image:           containerImage,
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args:            []string{},
 					Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 					VolumeMounts:    volumeMounts,


### PR DESCRIPTION
BuildTestPod creates raw Pods directly without going through lib-common workload helpers, so the recently added pod.SetPullPolicyDefaults does not apply. When ImagePullPolicy is not explicitly set and the image tag is "latest" or unset, Kubernetes defaults the policy to Always. Explicitly set PullIfNotPresent to avoid unnecessary image pulls.