### PR TITLE
Release test-operator-lock on CR deletion

### DIFF
--- a/internal/controller/ansibletest_controller.go
+++ b/internal/controller/ansibletest_controller.go
@@ -58,7 +58,6 @@ func (r *AnsibleTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		ServiceName:             ansibletest.ServiceName,
 		NeedsNetworkAttachments: false,
 		NeedsConfigMaps:         false,
-		NeedsFinalizer:          false,
 		SupportsWorkflow:        true,
 
 		BuildPod: func(ctx context.Context, instance *testv1beta1.AnsibleTest, labels, annotations map[string]string, workflowStepIndex int, pvcIndex int) (*corev1.Pod, error) {

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -51,6 +51,8 @@ const (
 const (
 	// ErrConfirmLockOwnership is the error message for lock ownership confirmation failures
 	ErrConfirmLockOwnership = "Can not confirm ownership of %s lock."
+	// ErrCleanupLock is the error message for failing to clean up the lock during pod deletion
+	ErrCleanupLock = "Failed to cleanup lock during pod deletion."
 )
 
 const (
@@ -608,6 +610,22 @@ func (r *Reconciler) ReleaseLock(ctx context.Context, instance client.Object) (b
 	}
 
 	return false, ErrFailedToDeleteLock
+}
+
+// CleanupLock removes the lock for the given instance without waiting for confirmation
+func (r *Reconciler) CleanupLock(ctx context.Context, instance client.Object) {
+	Log := r.GetLogger(ctx)
+
+	cm, err := r.GetLockInfo(ctx, instance)
+	if err != nil {
+		return
+	}
+
+	if cm.Data[testOperatorLockOwnerField] == string(instance.GetUID()) {
+		if err := r.Client.Delete(ctx, cm); err != nil {
+			Log.Info(ErrCleanupLock)
+		}
+	}
 }
 
 // GetPodIfExists returns the pod for the given instance and workflow step if it exists

--- a/internal/controller/common_controller.go
+++ b/internal/controller/common_controller.go
@@ -51,9 +51,6 @@ type TestResourceConfig[T TestResource] struct {
 	// NeedsConfigMaps indicates if ServiceConfigReadyCondition is needed
 	NeedsConfigMaps bool
 
-	// NeedsFinalizer indicates if the controller needs finalizer handling
-	NeedsFinalizer bool
-
 	// SupportsWorkflow indicates if the controller supports workflow feature
 	SupportsWorkflow bool
 
@@ -154,14 +151,15 @@ func CommonReconcile[T TestResource](
 
 	// If we're not deleting this and the service object doesn't have our
 	// finalizer, add it.
-	if config.NeedsFinalizer && instance.GetDeletionTimestamp().IsZero() &&
+	if instance.GetDeletionTimestamp().IsZero() &&
 		controllerutil.AddFinalizer(instance, helper.GetFinalizer()) {
 		return ctrl.Result{}, nil
 	}
 
 	// Handle service delete
-	if config.NeedsFinalizer && !instance.GetDeletionTimestamp().IsZero() {
+	if !instance.GetDeletionTimestamp().IsZero() {
 		Log.Info("Reconciling Service delete")
+		r.CleanupLock(ctx, instance)
 		controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 		Log.Info("Reconciled Service delete successfully")
 		return ctrl.Result{}, nil

--- a/internal/controller/horizontest_controller.go
+++ b/internal/controller/horizontest_controller.go
@@ -58,7 +58,6 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		ServiceName:             horizontest.ServiceName,
 		NeedsNetworkAttachments: false,
 		NeedsConfigMaps:         true,
-		NeedsFinalizer:          false,
 		SupportsWorkflow:        false,
 
 		GenerateServiceConfigMaps: func(ctx context.Context, helper *helper.Helper, labels map[string]string, instance *testv1beta1.HorizonTest, _ int) error {

--- a/internal/controller/tempest_controller.go
+++ b/internal/controller/tempest_controller.go
@@ -61,7 +61,6 @@ func (r *TempestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		ServiceName:             tempest.ServiceName,
 		NeedsNetworkAttachments: true,
 		NeedsConfigMaps:         true,
-		NeedsFinalizer:          true,
 		SupportsWorkflow:        true,
 
 		GenerateServiceConfigMaps: func(ctx context.Context, helper *helper.Helper, _ map[string]string, instance *testv1beta1.Tempest, workflowStep int) error {

--- a/internal/controller/tobiko_controller.go
+++ b/internal/controller/tobiko_controller.go
@@ -61,7 +61,6 @@ func (r *TobikoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		ServiceName:             tobiko.ServiceName,
 		NeedsNetworkAttachments: true,
 		NeedsConfigMaps:         true,
-		NeedsFinalizer:          false,
 		SupportsWorkflow:        true,
 
 		GenerateServiceConfigMaps: func(ctx context.Context, helper *helper.Helper, labels map[string]string, instance *testv1beta1.Tobiko, workflowStepIndex int) error {

--- a/test/functional/ansibletest_controller_test.go
+++ b/test/functional/ansibletest_controller_test.go
@@ -81,6 +81,12 @@ var _ = Describe("AnsibleTest controller", func() {
 			Expect(ansibleTest.Spec.AnsibleGitRepo).ShouldNot(BeEmpty())
 			Expect(ansibleTest.Spec.AnsiblePlaybookPath).ShouldNot(BeEmpty())
 		})
+
+		It("should have a finalizer", func() {
+			Eventually(func() []string {
+				return GetAnsibleTest(ansibleTestName).Finalizers
+			}, timeout, interval).Should(ContainElement("openstack.org/ansibletest"))
+		})
 	})
 
 	When("All dependencies are ready", func() {

--- a/test/functional/horizontest_controller_test.go
+++ b/test/functional/horizontest_controller_test.go
@@ -83,6 +83,12 @@ var _ = Describe("HorizonTest controller", func() {
 			Expect(horizonTest.Spec.DashboardUrl).ShouldNot(BeEmpty())
 			Expect(horizonTest.Spec.AuthUrl).ShouldNot(BeEmpty())
 		})
+
+		It("should have a finalizer", func() {
+			Eventually(func() []string {
+				return GetHorizonTest(horizonTestName).Finalizers
+			}, timeout, interval).Should(ContainElement("openstack.org/horizontest"))
+		})
 	})
 
 	When("All dependencies are ready", func() {

--- a/test/functional/tempest_controller_test.go
+++ b/test/functional/tempest_controller_test.go
@@ -86,8 +86,6 @@ var _ = Describe("Tempest controller", func() {
 		})
 
 		It("should have a finalizer", func() {
-			// the reconciler loop adds the finalizer so we have to wait for
-			// it to run
 			Eventually(func() []string {
 				return GetTempest(tempestName).Finalizers
 			}, timeout, interval).Should(ContainElement("openstack.org/tempest"))

--- a/test/functional/tobiko_controller_test.go
+++ b/test/functional/tobiko_controller_test.go
@@ -82,6 +82,11 @@ var _ = Describe("Tobiko controller", func() {
 			Expect(tobiko.Spec.Testenv).Should(Equal("sanity"))
 		})
 
+		It("should have a finalizer", func() {
+			Eventually(func() []string {
+				return GetTobiko(tobikoName).Finalizers
+			}, timeout, interval).Should(ContainElement("openstack.org/tobiko"))
+		})
 	})
 
 	When("All dependencies are ready", func() {


### PR DESCRIPTION
Previously, deleting a CR while its pod held the test-operator-lock left the lock stuck, blocking all other CR instances indefinitely. Finalizers are now added unconditionally so the lock is always released during deletion.