### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -14,8 +14,6 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/api/v1beta1/ansibletest_webhook.go
+++ b/api/v1beta1/ansibletest_webhook.go
@@ -28,14 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
 var ansibletestlog = logf.Log.WithName("ansibletest-resource")
-
-var _ webhook.Defaulter = &AnsibleTest{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *AnsibleTest) Default() {
@@ -43,8 +40,6 @@ func (r *AnsibleTest) Default() {
 
 	// TODO(user): fill in your defaulting logic.
 }
-
-var _ webhook.Validator = &AnsibleTest{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *AnsibleTest) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/horizontest_webhook.go
+++ b/api/v1beta1/horizontest_webhook.go
@@ -27,14 +27,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
 var horizontestlog = logf.Log.WithName("horizontest-resource")
-
-var _ webhook.Defaulter = &HorizonTest{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *HorizonTest) Default() {
@@ -42,8 +39,6 @@ func (r *HorizonTest) Default() {
 
 	// TODO(user): fill in your defaulting logic.
 }
-
-var _ webhook.Validator = &HorizonTest{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *HorizonTest) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/tempest_webhook.go
+++ b/api/v1beta1/tempest_webhook.go
@@ -29,14 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
 var tempestlog = logf.Log.WithName("tempest-resource")
-
-var _ webhook.Defaulter = &Tempest{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Tempest) Default() {
@@ -59,8 +56,6 @@ func (spec *TempestSpec) Default() {
 func (r *Tempest) PrivilegedRequired() bool {
 	return len(r.Spec.TempestRun.ExtraImages) > 0
 }
-
-var _ webhook.Validator = &Tempest{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Tempest) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/tobiko_webhook.go
+++ b/api/v1beta1/tobiko_webhook.go
@@ -29,14 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
 var tobikolog = logf.Log.WithName("tobiko-resource")
-
-var _ webhook.Defaulter = &Tobiko{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Tobiko) Default() {
@@ -44,8 +41,6 @@ func (r *Tobiko) Default() {
 
 	// TODO(user): fill in your defaulting logic.
 }
-
-var _ webhook.Validator = &Tobiko{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Tobiko) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)