### PR TITLE
Remove hardcoded passwords following install_yamls#1158

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20260717092345-ab1ee7b97c67
 	github.com/openstack-k8s-operators/test-operator/api v0.0.0-00010101000000-000000000000
 	go.uber.org/zap v1.28.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.13
 	k8s.io/apimachinery v0.33.13
 	k8s.io/client-go v0.33.13
@@ -24,6 +23,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 )
 

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -21,7 +21,6 @@ import (
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/pvc"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -779,76 +778,6 @@ func (r *Reconciler) VerifyNetworkAttachments(
 	}
 
 	return ctrl.Result{}, nil
-}
-
-// EnsureCloudsConfigMapExists ensures that frameworks like Tobiko and Horizon have password values
-// present in clouds.yaml. This code ensures that we set a default value of
-// 12345678 when password value is missing in the clouds.yaml
-func EnsureCloudsConfigMapExists(
-	ctx context.Context,
-	instance client.Object,
-	helper *helper.Helper,
-	labels map[string]string,
-	openstackConfigMapName string,
-) error {
-	const testOperatorCloudsConfigMapName = "test-operator-clouds-config"
-
-	cm, _, _ := configmap.GetConfigMap(
-		ctx,
-		helper,
-		instance,
-		testOperatorCloudsConfigMapName,
-		time.Second*10,
-	)
-	if cm.Name == testOperatorCloudsConfigMapName {
-		return nil
-	}
-
-	cm, _, _ = configmap.GetConfigMap(
-		ctx,
-		helper,
-		instance,
-		openstackConfigMapName,
-		time.Second*10,
-	)
-
-	result := make(map[string]interface{})
-
-	err := yaml.Unmarshal([]byte(cm.Data["clouds.yaml"]), &result)
-	if err != nil {
-		return err
-	}
-
-	clouds := result["clouds"].(map[string]interface{})
-	defaultValue := clouds["default"].(map[string]interface{})
-	auth := defaultValue["auth"].(map[string]interface{})
-
-	if _, ok := auth["password"].(string); !ok {
-		auth["password"] = "12345678"
-	}
-
-	yamlString, err := yaml.Marshal(result)
-	if err != nil {
-		return err
-	}
-
-	cms := []util.Template{
-		{
-			Name:      testOperatorCloudsConfigMapName,
-			Namespace: instance.GetNamespace(),
-			Type:      util.TemplateTypeNone,
-			Labels:    labels,
-			CustomData: map[string]string{
-				"clouds.yaml": string(yamlString),
-			},
-		},
-	}
-	err = configmap.EnsureConfigMaps(ctx, helper, instance, cms, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Int64OrPlaceholder converts int64 to string, returns placeholder if 0

--- a/internal/controller/horizontest_controller.go
+++ b/internal/controller/horizontest_controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	testv1beta1 "github.com/openstack-k8s-operators/test-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/test-operator/internal/horizontest"
 	corev1 "k8s.io/api/core/v1"
@@ -57,12 +56,8 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	config := TestResourceConfig[*testv1beta1.HorizonTest]{
 		ServiceName:             horizontest.ServiceName,
 		NeedsNetworkAttachments: false,
-		NeedsConfigMaps:         true,
+		NeedsConfigMaps:         false,
 		SupportsWorkflow:        false,
-
-		GenerateServiceConfigMaps: func(ctx context.Context, helper *helper.Helper, labels map[string]string, instance *testv1beta1.HorizonTest, _ int) error {
-			return r.generateServiceConfigMaps(ctx, helper, labels, instance)
-		},
 
 		BuildPod: func(ctx context.Context, instance *testv1beta1.HorizonTest, labels, annotations map[string]string, workflowStepIndex int, pvcIndex int) (*corev1.Pod, error) {
 			return r.buildHorizonTestPod(ctx, instance, labels, annotations, workflowStepIndex, pvcIndex)
@@ -72,7 +67,6 @@ func (r *HorizonTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return []*condition.Condition{
 				condition.UnknownCondition(condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage),
 				condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-				condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 				condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
 			}
 		},
@@ -132,22 +126,6 @@ func (r *HorizonTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}).
 		Complete(r)
-}
-
-func (r *HorizonTestReconciler) generateServiceConfigMaps(
-	ctx context.Context,
-	h *helper.Helper,
-	labels map[string]string,
-	instance *testv1beta1.HorizonTest,
-) error {
-	err := EnsureCloudsConfigMapExists(
-		ctx,
-		instance,
-		h,
-		labels,
-		instance.Spec.OpenStackConfigMap,
-	)
-	return err
 }
 
 // PrepareHorizonTestEnvVars prepares environment variables for HorizonTest execution

--- a/internal/controller/tobiko_controller.go
+++ b/internal/controller/tobiko_controller.go
@@ -174,17 +174,6 @@ func (r *TobikoReconciler) generateServiceConfigMaps(
 	instance *testv1beta1.Tobiko,
 	workflowStepIndex int,
 ) error {
-	err := EnsureCloudsConfigMapExists(
-		ctx,
-		instance,
-		h,
-		labels,
-		instance.Spec.OpenStackConfigMap,
-	)
-	if err != nil {
-		return err
-	}
-
 	templateSpecs := []struct {
 		infix string
 		key   string

--- a/internal/horizontest/volumes.go
+++ b/internal/horizontest/volumes.go
@@ -20,7 +20,7 @@ func GetVolumes(
 
 	volumes := []corev1.Volume{
 		util.CreateConfigMapVolume(horizonTestConfig, instance.Name+horizonTestConfig, util.ScriptsVolumeDefaultMode),
-		util.CreateOpenstackConfigMapVolume(util.TestOperatorCloudsConfigMapName),
+		util.CreateOpenstackConfigMapVolume(instance.Spec.OpenStackConfigMap),
 		util.CreateOpenstackConfigSecretVolume(instance.Spec.OpenStackConfigSecret),
 		util.CreateLogsPVCVolume(logsPVCName),
 		util.CreateWorkdirVolume(),
@@ -52,8 +52,8 @@ func GetVolumeMounts(
 		util.CreateVolumeMount(util.TestOperatorEphemeralVolumeNameWorkdir, "/var/lib/horizontest", false),
 		util.CreateVolumeMount(util.TestOperatorEphemeralVolumeNameTmp, "/tmp", false),
 		util.CreateVolumeMount(util.TestOperatorLogsVolumeName, "/var/lib/horizontest/external_files", false),
-		util.CreateTestOperatorCloudsConfigVolumeMount("/var/lib/horizontest/.config/openstack/clouds.yaml"),
-		util.CreateTestOperatorCloudsConfigVolumeMount("/etc/openstack/clouds.yaml"),
+		util.CreateOpenstackConfigVolumeMount(instance.Spec.OpenStackConfigMap, "/var/lib/horizontest/.config/openstack/clouds.yaml"),
+		util.CreateOpenstackConfigVolumeMount(instance.Spec.OpenStackConfigMap, "/etc/openstack/clouds.yaml"),
 		util.CreateOpenstackConfigSecretVolumeMount(instance.Spec.OpenStackConfigSecret, "/etc/openstack/secure.yaml"),
 	}
 

--- a/internal/tobiko/volumes.go
+++ b/internal/tobiko/volumes.go
@@ -48,7 +48,7 @@ func GetVolumes(
 
 	volumes := []corev1.Volume{
 		util.CreateConfigMapVolume(tobikoConfig, GetConfigMapName(instance, ConfigMapInfixConfig, workflowStepIndex), util.ScriptsVolumeDefaultMode),
-		util.CreateOpenstackConfigMapVolume(util.TestOperatorCloudsConfigMapName),
+		util.CreateOpenstackConfigMapVolume(instance.Spec.OpenStackConfigMap),
 		util.CreateOpenstackConfigSecretVolume(instance.Spec.OpenStackConfigSecret),
 		util.CreateLogsPVCVolume(logsPVCName),
 		util.CreateWorkdirVolume(),
@@ -88,8 +88,8 @@ func GetVolumeMounts(
 		util.CreateVolumeMount(util.TestOperatorEphemeralVolumeNameWorkdir, "/var/lib/tobiko", false),
 		util.CreateVolumeMount(util.TestOperatorEphemeralVolumeNameTmp, "/tmp", false),
 		util.CreateVolumeMount(util.TestOperatorLogsVolumeName, "/var/lib/tobiko/external_files", false),
-		util.CreateTestOperatorCloudsConfigVolumeMount("/var/lib/tobiko/.config/openstack/clouds.yaml"),
-		util.CreateTestOperatorCloudsConfigVolumeMount("/etc/openstack/clouds.yaml"),
+		util.CreateOpenstackConfigVolumeMount(instance.Spec.OpenStackConfigMap, "/var/lib/tobiko/.config/openstack/clouds.yaml"),
+		util.CreateOpenstackConfigVolumeMount(instance.Spec.OpenStackConfigMap, "/etc/openstack/clouds.yaml"),
 		util.CreateOpenstackConfigSecretVolumeMount(instance.Spec.OpenStackConfigSecret, "/etc/openstack/secure.yaml"),
 		util.CreateVolumeMountWithSubPath(tobikoConfig, "/etc/tobiko/tobiko.conf", ConfigFileName, false),
 	}

--- a/internal/util/common.go
+++ b/internal/util/common.go
@@ -9,11 +9,6 @@ import (
 )
 
 const (
-	// TestOperatorCloudsConfigMapName is the name of the ConfigMap which contains
-	// modified clouds.yaml obtained from openstack-config ConfigMap. The modified
-	// CM is needed by some test frameworks (e.g., HorizonTest and Tobiko)
-	TestOperatorCloudsConfigMapName = "test-operator-clouds-config"
-
 	// TestOperatorEphemeralVolumeNameWorkdir is the name of the ephemeral workdir volume
 	TestOperatorEphemeralVolumeNameWorkdir = "test-operator-ephemeral-workdir"
 

--- a/internal/util/volumes.go
+++ b/internal/util/volumes.go
@@ -273,11 +273,6 @@ func CreateOpenstackConfigSecretVolumeMount(secretName string, mountPath string)
 	return CreateVolumeMountWithSubPath(secretName, mountPath, subPathSecureYAML, false)
 }
 
-// CreateTestOperatorCloudsConfigVolumeMount creates a test-operator-clouds-config volume mount
-func CreateTestOperatorCloudsConfigVolumeMount(mountPath string) corev1.VolumeMount {
-	return CreateVolumeMountWithSubPath(TestOperatorCloudsConfigMapName, mountPath, subPathCloudsYAML, true)
-}
-
 // AppendExtraMountsVolumeMounts appends volume mounts from ExtraMounts spec
 func AppendExtraMountsVolumeMounts(
 	volumeMounts []corev1.VolumeMount,

--- a/test/functional/horizontest_controller_test.go
+++ b/test/functional/horizontest_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("HorizonTest controller", func() {
 		It("initializes the status fields", func() {
 			Eventually(func(g Gomega) {
 				horizonTest := GetHorizonTest(horizonTestName)
-				g.Expect(horizonTest.Status.Conditions).To(HaveLen(4))
+				g.Expect(horizonTest.Status.Conditions).To(HaveLen(3))
 				g.Expect(horizonTest.Status.Hash).To(BeEmpty())
 			}, timeout*2, interval).Should(Succeed())
 		})


### PR DESCRIPTION
A recent change [1] in install_yamls repository replaced hardcoded passwords with dynamically generated secrets. To keep test-operator up to date, it is needed to also update/remove hardcoded passwords, which is the goal of this PR. The new dynamic passwords also break EnsureCloudsConfigMapExists which injected "12345678" into clouds.yaml when empty, but that value no longer matches the real admin password.

This patch removes the workaround and has Tobiko and HorizonTest mount the original openstack-config ConfigMap directly. For HorizonTest, the password is read from osp-secret thanks to a ci-framework patch [2]. For Tobiko, a new way of supporting the password from secure.yaml is being worked on [3].

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/1158
[2] https://github.com/openstack-k8s-operators/ci-framework/pull/4067
[3] https://review.opendev.org/c/x/tobiko/+/998010

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4083