### PR TITLE
Deprecate AdminPassword and AdminUsername in HorizonTest CR

### DIFF
--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -54,18 +54,22 @@ spec:
                   operator.
                 type: string
               adminPassword:
-                default: admin
-                description: AdminPassword is the password for the OpenStack admin
-                  user.
+                default: ""
+                description: |-
+                  WARNING: This parameter will be deprecated!
+                  Please set the password in the OpenStackConfigSecret (secure.yaml) instead.
+                  When this parameter is empty the value is read from the secure.yaml.
+                  AdminPassword is the password for the OpenStack admin user.
                 maxLength: 253
-                minLength: 1
                 type: string
               adminUsername:
-                default: admin
-                description: AdminUsername is the username for the OpenStack admin
-                  user.
+                default: ""
+                description: |-
+                  WARNING: This parameter will be deprecated!
+                  Please set the username in the OpenStackConfigMap (clouds.yaml) instead.
+                  When this parameter is empty the value is read from the clouds.yaml.
+                  AdminUsername is the username for the OpenStack admin user.
                 maxLength: 253
-                minLength: 1
                 type: string
               authUrl:
                 description: AuthUrl is the authentication URL for OpenStack.
@@ -1457,8 +1461,6 @@ spec:
                 maxLength: 253
                 type: string
             required:
-            - adminPassword
-            - adminUsername
             - authUrl
             - dashboardUrl
             - horizonRepoBranch

--- a/api/v1beta1/horizontest_types.go
+++ b/api/v1beta1/horizontest_types.go
@@ -59,19 +59,23 @@ type HorizonTestSpec struct {
 	// on the u/s or d/s theme
 	ProjectTextXpath string `json:"projectTextXpath"`
 
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxLength=253
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="admin"
+	// +kubebuilder:default:=""
+	// WARNING: This parameter will be deprecated!
+	// Please set the username in the OpenStackConfigMap (clouds.yaml) instead.
+	// When this parameter is empty the value is read from the clouds.yaml.
 	// AdminUsername is the username for the OpenStack admin user.
 	AdminUsername string `json:"adminUsername"`
 
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxLength=253
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="admin"
+	// +kubebuilder:default:=""
+	// WARNING: This parameter will be deprecated!
+	// Please set the password in the OpenStackConfigSecret (secure.yaml) instead.
+	// When this parameter is empty the value is read from the secure.yaml.
 	// AdminPassword is the password for the OpenStack admin user.
 	AdminPassword string `json:"adminPassword"`
 

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -54,18 +54,22 @@ spec:
                   operator.
                 type: string
               adminPassword:
-                default: admin
-                description: AdminPassword is the password for the OpenStack admin
-                  user.
+                default: ""
+                description: |-
+                  WARNING: This parameter will be deprecated!
+                  Please set the password in the OpenStackConfigSecret (secure.yaml) instead.
+                  When this parameter is empty the value is read from the secure.yaml.
+                  AdminPassword is the password for the OpenStack admin user.
                 maxLength: 253
-                minLength: 1
                 type: string
               adminUsername:
-                default: admin
-                description: AdminUsername is the username for the OpenStack admin
-                  user.
+                default: ""
+                description: |-
+                  WARNING: This parameter will be deprecated!
+                  Please set the username in the OpenStackConfigMap (clouds.yaml) instead.
+                  When this parameter is empty the value is read from the clouds.yaml.
+                  AdminUsername is the username for the OpenStack admin user.
                 maxLength: 253
-                minLength: 1
                 type: string
               authUrl:
                 description: AuthUrl is the authentication URL for OpenStack.
@@ -1457,8 +1461,6 @@ spec:
                 maxLength: 253
                 type: string
             required:
-            - adminPassword
-            - adminUsername
             - authUrl
             - dashboardUrl
             - horizonRepoBranch

--- a/config/samples/test_v1beta1_horizontest.yaml
+++ b/config/samples/test_v1beta1_horizontest.yaml
@@ -13,10 +13,6 @@ spec:
   # debug: false
   storageClass: "local-storage"
 
-  # OpenStack admin credentials
-  adminUsername: "admin"
-  adminPassword: "12345678"
-
   # The URL of the Horizon dashboard
   dashboardUrl: "https://horizon-openstack.apps.ocp.openstack.lab/"
 


### PR DESCRIPTION
These fields stored credentials as plaintext in the CR spec. When left empty (the new default), the container reads credentials from the already-mounted clouds.yaml and secure.yaml instead.

In the future, these parameters will be removed, so that users set them in clouds.yaml and secure.yaml, creating one source of truth.