### PR TITLE
Remove unused fields from HorizonTest CR

### DIFF
--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -1252,34 +1252,15 @@ spec:
                   - extraVol
                   type: object
                 type: array
-              flavorName:
-                default: m1.tiny
-                description: FlavorName is the name of the OpenStack flavor to create
-                  for Horizon tests.
-                type: string
               horizonRepoBranch:
                 default: master
                 description: HorizonRepoBranch is the branch of the Horizon repository
                   to checkout.
                 type: string
-              horizonTestDir:
-                default: /var/lib/horizontest
-                description: HorizonTestDir is the directory path for Horizon tests.
-                type: string
-              imageUrl:
-                default: http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
-                description: ImageUrl is the URL to download the Cirros image.
-                format: uri
-                type: string
               kubeconfigSecretName:
                 description: |-
                   Name of a secret that contains a kubeconfig. The kubeconfig is mounted under /var/lib/horizontest/.kube/config
                   in the test pod.
-                type: string
-              logsDirectoryName:
-                default: horizon
-                description: LogsDirectoryName is the name of the directory to store
-                  test logs.
                 type: string
               nodeSelector:
                 additionalProperties:
@@ -1302,12 +1283,6 @@ spec:
                 default: false
                 description: Parallel
                 type: boolean
-              password:
-                default: horizontest
-                description: Password is the password for the user running the Horizon
-                  tests.
-                maxLength: 253
-                type: string
               privileged:
                 default: false
                 description: |-
@@ -1319,11 +1294,6 @@ spec:
                   needed for certain test-operator functionalities to work properly (e.g.:
                   extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
-              projectName:
-                default: horizontest
-                description: ProjectName is the name of the OpenStack project for
-                  Horizon tests.
-                type: string
               projectNameXpath:
                 description: |-
                   ProjectNameXpath is the xpath to select project name
@@ -1454,12 +1424,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              user:
-                default: horizontest
-                description: User is the username under which the Horizon tests will
-                  run.
-                maxLength: 253
-                type: string
             required:
             - authUrl
             - dashboardUrl

--- a/api/v1beta1/horizontest_types.go
+++ b/api/v1beta1/horizontest_types.go
@@ -105,51 +105,6 @@ type HorizonTestSpec struct {
 	HorizonRepoBranch string `json:"horizonRepoBranch"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Format=uri
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img"
-	// ImageUrl is the URL to download the Cirros image.
-	ImageUrl string `json:"imageUrl"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="horizontest"
-	// ProjectName is the name of the OpenStack project for Horizon tests.
-	ProjectName string `json:"projectName"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:MaxLength=253
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="horizontest"
-	// User is the username under which the Horizon tests will run.
-	User string `json:"user"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:MaxLength=253
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="horizontest"
-	// Password is the password for the user running the Horizon tests.
-	Password string `json:"password"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="m1.tiny"
-	// FlavorName is the name of the OpenStack flavor to create for Horizon tests.
-	FlavorName string `json:"flavorName"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="horizon"
-	// LogsDirectoryName is the name of the directory to store test logs.
-	LogsDirectoryName string `json:"logsDirectoryName"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:default:="/var/lib/horizontest"
-	// HorizonTestDir is the directory path for Horizon tests.
-	HorizonTestDir string `json:"horizonTestDir"`
-
-	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:default:=false
 	// Parallel

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -1252,34 +1252,15 @@ spec:
                   - extraVol
                   type: object
                 type: array
-              flavorName:
-                default: m1.tiny
-                description: FlavorName is the name of the OpenStack flavor to create
-                  for Horizon tests.
-                type: string
               horizonRepoBranch:
                 default: master
                 description: HorizonRepoBranch is the branch of the Horizon repository
                   to checkout.
                 type: string
-              horizonTestDir:
-                default: /var/lib/horizontest
-                description: HorizonTestDir is the directory path for Horizon tests.
-                type: string
-              imageUrl:
-                default: http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
-                description: ImageUrl is the URL to download the Cirros image.
-                format: uri
-                type: string
               kubeconfigSecretName:
                 description: |-
                   Name of a secret that contains a kubeconfig. The kubeconfig is mounted under /var/lib/horizontest/.kube/config
                   in the test pod.
-                type: string
-              logsDirectoryName:
-                default: horizon
-                description: LogsDirectoryName is the name of the directory to store
-                  test logs.
                 type: string
               nodeSelector:
                 additionalProperties:
@@ -1302,12 +1283,6 @@ spec:
                 default: false
                 description: Parallel
                 type: boolean
-              password:
-                default: horizontest
-                description: Password is the password for the user running the Horizon
-                  tests.
-                maxLength: 253
-                type: string
               privileged:
                 default: false
                 description: |-
@@ -1319,11 +1294,6 @@ spec:
                   needed for certain test-operator functionalities to work properly (e.g.:
                   extraRPMs in Tempest CR, or a certain set of tobiko tests).
                 type: boolean
-              projectName:
-                default: horizontest
-                description: ProjectName is the name of the OpenStack project for
-                  Horizon tests.
-                type: string
               projectNameXpath:
                 description: |-
                   ProjectNameXpath is the xpath to select project name
@@ -1454,12 +1424,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              user:
-                default: horizontest
-                description: User is the username under which the Horizon tests will
-                  run.
-                maxLength: 253
-                type: string
             required:
             - authUrl
             - dashboardUrl

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -251,10 +251,18 @@ spec:
           operator.
         displayName: SELinux Level
         path: SELinuxLevel
-      - description: AdminPassword is the password for the OpenStack admin user.
+      - description: |-
+          WARNING: This parameter will be deprecated!
+          Please set the password in the OpenStackConfigSecret (secure.yaml) instead.
+          When this parameter is empty the value is read from the secure.yaml.
+          AdminPassword is the password for the OpenStack admin user.
         displayName: Admin Password
         path: adminPassword
-      - description: AdminUsername is the username for the OpenStack admin user.
+      - description: |-
+          WARNING: This parameter will be deprecated!
+          Please set the username in the OpenStackConfigMap (clouds.yaml) instead.
+          When this parameter is empty the value is read from the clouds.yaml.
+          AdminUsername is the username for the OpenStack admin user.
         displayName: Admin Username
         path: adminUsername
       - description: AuthUrl is the authentication URL for OpenStack.
@@ -302,20 +310,10 @@ spec:
         path: extraMounts[0].name
       - displayName: Region
         path: extraMounts[0].region
-      - description: FlavorName is the name of the OpenStack flavor to create for
-          Horizon tests.
-        displayName: Flavor Name
-        path: flavorName
       - description: HorizonRepoBranch is the branch of the Horizon repository to
           checkout.
         displayName: Horizon Repo Branch
         path: horizonRepoBranch
-      - description: HorizonTestDir is the directory path for Horizon tests.
-        displayName: Horizon Test Dir
-        path: horizonTestDir
-      - description: ImageUrl is the URL to download the Cirros image.
-        displayName: Image Url
-        path: imageUrl
       - description: |-
           Name of a secret that contains a kubeconfig. The kubeconfig is mounted under /var/lib/horizontest/.kube/config
           in the test pod.
@@ -323,21 +321,22 @@ spec:
         path: kubeconfigSecretName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
-      - description: LogsDirectoryName is the name of the directory to store test
-          logs.
-        displayName: Logs Directory Name
-        path: logsDirectoryName
       - description: |-
           This value contains a nodeSelector value that is applied to test pods
           spawned by the test operator.
         displayName: Node Selector
         path: nodeSelector
+      - description: OpenStackConfigMap is the name of the ConfigMap containing the
+          clouds.yaml
+        displayName: Open Stack Config Map
+        path: openStackConfigMap
+      - description: OpenStackConfigSecret is the name of the Secret containing the
+          secure.yaml
+        displayName: Open Stack Config Secret
+        path: openStackConfigSecret
       - description: Parallel
         displayName: Parallel
         path: parallel
-      - description: Password is the password for the user running the Horizon tests.
-        displayName: Password
-        path: password
       - description: |-
           Use with caution! This parameter specifies whether test-operator should spawn
           test pods with allowedPrivilegedEscalation: true, readOnlyRootFilesystem: false,
@@ -348,15 +347,17 @@ spec:
           extraRPMs in Tempest CR, or a certain set of tobiko tests).
         displayName: Privileged
         path: privileged
-      - description: ProjectName is the name of the OpenStack project for Horizon
-          tests.
-        displayName: Project Name
-        path: projectName
       - description: |-
           ProjectNameXpath is the xpath to select project name
           on the horizon dashboard based on the u/s or d/s theme
         displayName: Project Name Xpath
         path: projectNameXpath
+      - description: |-
+          ProjectTextXpath is the xpath to element displaying
+          current project name on the horizon dashboard based
+          on the u/s or d/s theme
+        displayName: Project Text Xpath
+        path: projectTextXpath
       - description: RepoUrl is the URL of the Horizon repository.
         displayName: Repo Url
         path: repoUrl
@@ -368,9 +369,6 @@ spec:
           test pods that are spawned by the test-operator.
         displayName: Tolerations
         path: tolerations
-      - description: User is the username under which the Horizon tests will run.
-        displayName: User
-        path: user
       version: v1beta1
     - displayName: Tempest
       kind: Tempest
@@ -1093,6 +1091,14 @@ spec:
           0 results in automatic decision
         displayName: Num Processes
         path: numProcesses
+      - description: OpenStackConfigMap is the name of the ConfigMap containing the
+          clouds.yaml
+        displayName: Open Stack Config Map
+        path: openStackConfigMap
+      - description: OpenStackConfigSecret is the name of the Secret containing the
+          secure.yaml
+        displayName: Open Stack Config Secret
+        path: openStackConfigSecret
       - description: |-
           By default test-operator executes the test-pods sequentially if multiple
           instances of test-operator related CRs exist. To run test-pods in parallel
@@ -1126,6 +1132,11 @@ spec:
           tests
         displayName: Pytest Addopts
         path: pytestAddopts
+      - description: |-
+          List of test name patterns to skip. It has the same functionality
+          as the --skipregex parameter used in PytestAddopts.
+        displayName: Skip Regex List
+        path: skipRegexList
       - description: StorageClass used to create any test-operator related PVCs.
         displayName: Storage Class
         path: storageClass
@@ -1199,6 +1210,14 @@ spec:
           0 results in automatic decision
         displayName: Num Processes
         path: workflow[0].numProcesses
+      - description: OpenStackConfigMap is the name of the ConfigMap containing the
+          clouds.yaml
+        displayName: Open Stack Config Map
+        path: workflow[0].openStackConfigMap
+      - description: OpenStackConfigSecret is the name of the Secret containing the
+          secure.yaml
+        displayName: Open Stack Config Secret
+        path: workflow[0].openStackConfigSecret
       - description: Optional patch to apply to the Tobiko repository for this step.
         displayName: Patch
         path: workflow[0].patch
@@ -1225,6 +1244,11 @@ spec:
           tests
         displayName: Pytest Addopts
         path: workflow[0].pytestAddopts
+      - description: |-
+          List of test name patterns to skip. It has the same functionality
+          as the --skipregex parameter used in PytestAddopts.
+        displayName: Skip Regex List
+        path: workflow[0].skipRegexList
       - description: A parameter that contains a definition of a single workflow step.
         displayName: Step Name
         path: workflow[0].stepName

--- a/config/samples/test_v1beta1_horizontest.yaml
+++ b/config/samples/test_v1beta1_horizontest.yaml
@@ -25,27 +25,6 @@ spec:
   # The branch of the Horizon repository to checkout
   horizonRepoBranch: "master"
 
-  # The URL to download the Cirros image (optional)
-  imageUrl: "http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img"
-
-  # The name of the OpenStack project for Horizon tests (optional)
-  projectName: "horizontest"
-
-  # The username under which Horizon tests will run (optional)
-  user: "horizontest"
-
-  # The password for the user running the Horizon tests (optional)
-  password: "horizontest"
-
-  # The name of the OpenStack flavor to create for Horizon tests (optional)
-  flavorName: "m1.tiny"
-
-  # The name of the directory to store test logs (optional)
-  logsDirectoryName: "horizon"
-
-  # The directory path for Horizon tests (optional)
-  horizonTestDir: "/var/lib/horizontest"
-
   # Whether to run tests in parallel (optional)
   parallel: false
 

--- a/internal/controller/horizontest_controller.go
+++ b/internal/controller/horizontest_controller.go
@@ -142,8 +142,7 @@ func (r *HorizonTestReconciler) PrepareHorizonTestEnvVars(
 
 	// String
 	SetStringEnvVars(envVars, map[string]string{
-		"USE_EXTERNAL_FILES":    "True",
-		"HORIZON_LOGS_DIR_NAME": "horizon",
+		"USE_EXTERNAL_FILES": "True",
 
 		// Mandatory variables
 		"ADMIN_USERNAME":      instance.Spec.AdminUsername,
@@ -153,18 +152,10 @@ func (r *HorizonTestReconciler) PrepareHorizonTestEnvVars(
 		"REPO_URL":            instance.Spec.RepoUrl,
 		"HORIZON_REPO_BRANCH": instance.Spec.HorizonRepoBranch,
 
-		// Horizon specific configuration
-		"IMAGE_FILE":          "/var/lib/horizontest/cirros-0.6.2-x86_64-disk.img",
-		"IMAGE_FILE_NAME":     "cirros-0.6.2-x86_64-disk",
-		"IMAGE_URL":           "http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img",
-		"PROJECT_NAME":        "horizontest",
-		"USER_NAME":           "horizontest",
-		"PASSWORD":            "horizontest",
-		"FLAVOR_NAME":         "m1.tiny",
-		"HORIZON_KEYS_FOLDER": "/etc/test_operator",
-		"EXTRA_FLAG":          instance.Spec.ExtraFlag,
-		"PROJECT_NAME_XPATH":  instance.Spec.ProjectNameXpath,
-		"PROJECT_TEXT_XPATH":  instance.Spec.ProjectTextXpath,
+		// Optional variables
+		"EXTRA_FLAG":         instance.Spec.ExtraFlag,
+		"PROJECT_NAME_XPATH": instance.Spec.ProjectNameXpath,
+		"PROJECT_TEXT_XPATH": instance.Spec.ProjectTextXpath,
 	})
 
 	return envVars


### PR DESCRIPTION
The ProjectName, User, Password fields were never read by the controller. In TCIB it is hardcoded as "horizontest" regardless of what was set in the CR.

Normally, I would recommend deprecation for parameters, but since these parameters never worked from the start, I suggest a removal. There is also no need for them to be parameters, as the Horizon team agreed they do not have to be overwritten and can stay hardcoded.