### PR TITLE
Add logic for pending pods timeout

### DIFF
--- a/api/bases/test.openstack.org_ansibletests.yaml
+++ b/api/bases/test.openstack.org_ansibletests.yaml
@@ -879,6 +879,11 @@ spec:
                 description: OpenStackConfigSecret is the name of the Secret containing
                   the secure.yaml
                 type: string
+              pendingTimeout:
+                description: |-
+                  Timeout after which a test pod in the Pending state is considered
+                  stuck and its execution is terminated.
+                type: integer
               privileged:
                 default: false
                 description: |-
@@ -1110,6 +1115,11 @@ spec:
                       description: OpenStackConfigSecret is the name of the Secret
                         containing the secure.yaml
                       type: string
+                    pendingTimeout:
+                      description: |-
+                        Timeout after which a test pod in the Pending state is considered
+                        stuck and its execution is terminated.
+                      type: integer
                     privileged:
                       description: |-
                         Use with caution! This parameter specifies whether test-operator should spawn test

--- a/api/bases/test.openstack.org_horizontests.yaml
+++ b/api/bases/test.openstack.org_horizontests.yaml
@@ -886,6 +886,11 @@ spec:
                 default: false
                 description: Parallel
                 type: boolean
+              pendingTimeout:
+                description: |-
+                  Timeout after which a test pod in the Pending state is considered
+                  stuck and its execution is terminated.
+                type: integer
               privileged:
                 default: false
                 description: |-

--- a/api/bases/test.openstack.org_tempests.yaml
+++ b/api/bases/test.openstack.org_tempests.yaml
@@ -878,6 +878,11 @@ spec:
                   instances of test-operator related CRs exist. If you want to turn off this
                   behaviour then set this option to true.
                 type: boolean
+              pendingTimeout:
+                description: |-
+                  Timeout after which a test pod in the Pending state is considered
+                  stuck and its execution is terminated.
+                type: integer
               privileged:
                 default: false
                 description: |-
@@ -1451,6 +1456,11 @@ spec:
                         instances of test-operator related CRs exist. If you want to turn off this
                         behaviour then set this option to true.
                       type: boolean
+                    pendingTimeout:
+                      description: |-
+                        Timeout after which a test pod in the Pending state is considered
+                        stuck and its execution is terminated.
+                      type: integer
                     privileged:
                       description: |-
                         Use with caution! This parameter specifies whether test-operator should spawn test

--- a/api/bases/test.openstack.org_tobikoes.yaml
+++ b/api/bases/test.openstack.org_tobikoes.yaml
@@ -884,6 +884,11 @@ spec:
                     format: uri
                     type: string
                 type: object
+              pendingTimeout:
+                description: |-
+                  Timeout after which a test pod in the Pending state is considered
+                  stuck and its execution is terminated.
+                type: integer
               preventCreate:
                 default: false
                 description: Boolean specifying whether tobiko tests create new resources
@@ -1144,6 +1149,11 @@ spec:
                           format: uri
                           type: string
                       type: object
+                    pendingTimeout:
+                      description: |-
+                        Timeout after which a test pod in the Pending state is considered
+                        stuck and its execution is terminated.
+                      type: integer
                     preventCreate:
                       description: Boolean specifying whether tobiko tests create
                         new resources or re-use those previously created

--- a/api/v1beta1/ansibletest_types.go
+++ b/api/v1beta1/ansibletest_types.go
@@ -226,6 +226,11 @@ func (instance *AnsibleTest) GetConditions() *condition.Conditions {
 	return &instance.Status.Conditions
 }
 
+// GetPendingTimeout - return the pending timeout
+func (instance *AnsibleTest) GetPendingTimeout() int {
+	return instance.Spec.PendingTimeout
+}
+
 // GetStorageClass - return the storage class name
 func (instance *AnsibleTest) GetStorageClass() string {
 	return instance.Spec.StorageClass

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -95,6 +95,12 @@ type CommonOptions struct {
 	// ExtraMounts containing conf files, credentials and storage volumes
 	ExtraMounts []ExtraVolMounts `json:"extraMounts,omitempty"`
 
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:Optional
+	// Timeout after which a test pod in the Pending state is considered
+	// stuck and its execution is terminated.
+	PendingTimeout int `json:"pendingTimeout"`
+
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// This value contains a nodeSelector value that is applied to test pods
@@ -185,6 +191,12 @@ type WorkflowCommonOptions struct {
 	// WARNING: This parameter will be deprecated!
 	// Please use ExtraMounts parameter instead!
 	ExtraConfigmapsMounts *[]ExtraConfigmapsMounts `json:"extraConfigmapsMounts,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:Optional
+	// Timeout after which a test pod in the Pending state is considered
+	// stuck and its execution is terminated.
+	PendingTimeout *int `json:"pendingTimeout,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1beta1/horizontest_types.go
+++ b/api/v1beta1/horizontest_types.go
@@ -163,6 +163,11 @@ func (instance *HorizonTest) GetConditions() *condition.Conditions {
 	return &instance.Status.Conditions
 }
 
+// GetPendingTimeout - return the pending timeout
+func (instance *HorizonTest) GetPendingTimeout() int {
+	return instance.Spec.PendingTimeout
+}
+
 // GetStorageClass - return the storage class name
 func (instance *HorizonTest) GetStorageClass() string {
 	return instance.Spec.StorageClass

--- a/api/v1beta1/tempest_types.go
+++ b/api/v1beta1/tempest_types.go
@@ -528,6 +528,11 @@ func (instance *Tempest) GetConditions() *condition.Conditions {
 	return &instance.Status.Conditions
 }
 
+// GetPendingTimeout - return the pending timeout
+func (instance *Tempest) GetPendingTimeout() int {
+	return instance.Spec.PendingTimeout
+}
+
 // GetStorageClass - return the storage class name
 func (instance *Tempest) GetStorageClass() string {
 	return instance.Spec.StorageClass

--- a/api/v1beta1/tobiko_types.go
+++ b/api/v1beta1/tobiko_types.go
@@ -266,6 +266,11 @@ func (instance *Tobiko) GetConditions() *condition.Conditions {
 	return &instance.Status.Conditions
 }
 
+// GetPendingTimeout - return the pending timeout
+func (instance *Tobiko) GetPendingTimeout() int {
+	return instance.Spec.PendingTimeout
+}
+
 // GetStorageClass - return the storage class name
 func (instance *Tobiko) GetStorageClass() string {
 	return instance.Spec.StorageClass

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -746,6 +746,11 @@ func (in *WorkflowCommonOptions) DeepCopyInto(out *WorkflowCommonOptions) {
 			copy(*out, *in)
 		}
 	}
+	if in.PendingTimeout != nil {
+		in, out := &in.PendingTimeout, &out.PendingTimeout
+		*out = new(int)
+		**out = **in
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = new(map[string]string)

--- a/config/crd/bases/test.openstack.org_ansibletests.yaml
+++ b/config/crd/bases/test.openstack.org_ansibletests.yaml
@@ -879,6 +879,11 @@ spec:
                 description: OpenStackConfigSecret is the name of the Secret containing
                   the secure.yaml
                 type: string
+              pendingTimeout:
+                description: |-
+                  Timeout after which a test pod in the Pending state is considered
+                  stuck and its execution is terminated.
+                type: integer
               privileged:
                 default: false
                 description: |-
@@ -1110,6 +1115,11 @@ spec:
                       description: OpenStackConfigSecret is the name of the Secret
                         containing the secure.yaml
                       type: string
+                    pendingTimeout:
+                      description: |-
+                        Timeout after which a test pod in the Pending state is considered
+                        stuck and its execution is terminated.
+                      type: integer
                     privileged:
                       description: |-
                         Use with caution! This parameter specifies whether test-operator should spawn test

--- a/config/crd/bases/test.openstack.org_horizontests.yaml
+++ b/config/crd/bases/test.openstack.org_horizontests.yaml
@@ -886,6 +886,11 @@ spec:
                 default: false
                 description: Parallel
                 type: boolean
+              pendingTimeout:
+                description: |-
+                  Timeout after which a test pod in the Pending state is considered
+                  stuck and its execution is terminated.
+                type: integer
               privileged:
                 default: false
                 description: |-

--- a/config/crd/bases/test.openstack.org_tempests.yaml
+++ b/config/crd/bases/test.openstack.org_tempests.yaml
@@ -878,6 +878,11 @@ spec:
                   instances of test-operator related CRs exist. If you want to turn off this
                   behaviour then set this option to true.
                 type: boolean
+              pendingTimeout:
+                description: |-
+                  Timeout after which a test pod in the Pending state is considered
+                  stuck and its execution is terminated.
+                type: integer
               privileged:
                 default: false
                 description: |-
@@ -1451,6 +1456,11 @@ spec:
                         instances of test-operator related CRs exist. If you want to turn off this
                         behaviour then set this option to true.
                       type: boolean
+                    pendingTimeout:
+                      description: |-
+                        Timeout after which a test pod in the Pending state is considered
+                        stuck and its execution is terminated.
+                      type: integer
                     privileged:
                       description: |-
                         Use with caution! This parameter specifies whether test-operator should spawn test

--- a/config/crd/bases/test.openstack.org_tobikoes.yaml
+++ b/config/crd/bases/test.openstack.org_tobikoes.yaml
@@ -884,6 +884,11 @@ spec:
                     format: uri
                     type: string
                 type: object
+              pendingTimeout:
+                description: |-
+                  Timeout after which a test pod in the Pending state is considered
+                  stuck and its execution is terminated.
+                type: integer
               preventCreate:
                 default: false
                 description: Boolean specifying whether tobiko tests create new resources
@@ -1144,6 +1149,11 @@ spec:
                           format: uri
                           type: string
                       type: object
+                    pendingTimeout:
+                      description: |-
+                        Timeout after which a test pod in the Pending state is considered
+                        stuck and its execution is terminated.
+                      type: integer
                     preventCreate:
                       description: Boolean specifying whether tobiko tests create
                         new resources or re-use those previously created

--- a/config/manifests/bases/test-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/test-operator.clusterserviceversion.yaml
@@ -109,6 +109,11 @@ spec:
         displayName: Open Stack Config Secret
         path: openStackConfigSecret
       - description: |-
+          Timeout after which a test pod in the Pending state is considered
+          stuck and its execution is terminated.
+        displayName: Pending Timeout
+        path: pendingTimeout
+      - description: |-
           Use with caution! This parameter specifies whether test-operator should spawn
           test pods with allowedPrivilegedEscalation: true, readOnlyRootFilesystem: false,
           runAsNonRoot: false, automountServiceAccountToken: true, and the default
@@ -209,6 +214,11 @@ spec:
           secure.yaml
         displayName: Open Stack Config Secret
         path: workflow[0].openStackConfigSecret
+      - description: |-
+          Timeout after which a test pod in the Pending state is considered
+          stuck and its execution is terminated.
+        displayName: Pending Timeout
+        path: workflow[0].pendingTimeout
       - description: |-
           Use with caution! This parameter specifies whether test-operator should spawn test
           pods with allowedPrivilegedEscalation: true and the default capabilities on
@@ -338,6 +348,11 @@ spec:
         displayName: Parallel
         path: parallel
       - description: |-
+          Timeout after which a test pod in the Pending state is considered
+          stuck and its execution is terminated.
+        displayName: Pending Timeout
+        path: pendingTimeout
+      - description: |-
           Use with caution! This parameter specifies whether test-operator should spawn
           test pods with allowedPrivilegedEscalation: true, readOnlyRootFilesystem: false,
           runAsNonRoot: false, automountServiceAccountToken: true, and the default
@@ -461,6 +476,11 @@ spec:
           behaviour then set this option to true.
         displayName: Parallel
         path: parallel
+      - description: |-
+          Timeout after which a test pod in the Pending state is considered
+          stuck and its execution is terminated.
+        displayName: Pending Timeout
+        path: pendingTimeout
       - description: |-
           Use with caution! This parameter specifies whether test-operator should spawn
           test pods with allowedPrivilegedEscalation: true, readOnlyRootFilesystem: false,
@@ -777,6 +797,11 @@ spec:
           behaviour then set this option to true.
         displayName: Parallel
         path: workflow[0].parallel
+      - description: |-
+          Timeout after which a test pod in the Pending state is considered
+          stuck and its execution is terminated.
+        displayName: Pending Timeout
+        path: workflow[0].pendingTimeout
       - description: |-
           Use with caution! This parameter specifies whether test-operator should spawn test
           pods with allowedPrivilegedEscalation: true and the default capabilities on
@@ -1108,6 +1133,11 @@ spec:
       - description: Optional patch to apply to the Tobiko repository.
         displayName: Patch
         path: patch
+      - description: |-
+          Timeout after which a test pod in the Pending state is considered
+          stuck and its execution is terminated.
+        displayName: Pending Timeout
+        path: pendingTimeout
       - description: Boolean specifying whether tobiko tests create new resources
           or re-use those previously created
         displayName: Prevent Create
@@ -1221,6 +1251,11 @@ spec:
       - description: Optional patch to apply to the Tobiko repository for this step.
         displayName: Patch
         path: workflow[0].patch
+      - description: |-
+          Timeout after which a test pod in the Pending state is considered
+          stuck and its execution is terminated.
+        displayName: Pending Timeout
+        path: workflow[0].pendingTimeout
       - description: Boolean specifying whether tobiko tests create new resources
           or re-use those previously created
         displayName: Prevent Create

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -42,6 +42,7 @@ const (
 	workflowStepLabel          = "workflowStep"
 	instanceNameLabel          = "instanceName"
 	operatorNameLabel          = "operator"
+	pendingTimeoutAnnotation   = "test.openstack.org/pending-timeout"
 	testOperatorLockName       = "test-operator-lock"
 	testOperatorLockOwnerField = "owner"
 	testOperatorBaseDir        = "/etc/test_operator/"
@@ -59,6 +60,8 @@ const (
 	InfoWaitingOnPod = "Waiting on either pod to finish or release of the lock."
 	// InfoPendingPod is the info message when waiting for a pending pod to start
 	InfoPendingPod = "Waiting for pending pod to start running."
+	// InfoPendingPodTimeout is the info message when a pending pod exceeds its timeout
+	InfoPendingPodTimeout = "Pod exceeded pending timeout."
 	// InfoTestingCompleted is the info message when all testing is completed
 	InfoTestingCompleted = "Testing completed. All pods spawned by the test-operator finished."
 	// InfoCreatingFirstPod is the info message when creating the first test pod
@@ -202,6 +205,15 @@ func (r *Reconciler) NextAction(
 		workflowStepIdx, err := strconv.Atoi(lastPod.Labels[workflowStepLabel])
 		if err != nil {
 			return Failure, workflowStepIdx, err
+		}
+
+		// if the last pod has exceeded pending timeout
+		if lastPod.Annotations[pendingTimeoutAnnotation] == "true" {
+			if !isLastPodIndex(workflowStepIdx, workflowLength) {
+				workflowStepIdx++
+				return CreateNextPod, workflowStepIdx, nil
+			}
+			return EndTesting, workflowStepIdx, nil
 		}
 
 		switch lastPod.Status.Phase {

--- a/internal/controller/common_controller.go
+++ b/internal/controller/common_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -36,6 +37,7 @@ import (
 type TestResource interface {
 	client.Object
 	GetConditions() *condition.Conditions
+	GetPendingTimeout() int
 	GetStorageClass() string
 	SetObservedGeneration()
 }
@@ -209,8 +211,33 @@ func CommonReconcile[T TestResource](
 
 	switch nextAction {
 	case CheckPending:
-		Log.Info(InfoPendingPod)
-		return ctrl.Result{RequeueAfter: RequeueAfterValue}, nil
+		pendingTimeout := time.Duration(instance.GetPendingTimeout()) * time.Second
+
+		lastPod, err := r.GetLastPod(ctx, instance)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if pendingTimeout <= 0 || time.Since(lastPod.CreationTimestamp.Time) <= pendingTimeout {
+			Log.Info(InfoPendingPod)
+			return ctrl.Result{RequeueAfter: RequeueAfterValue}, nil
+		}
+
+		Log.Info(InfoPendingPodTimeout)
+
+		if lastPod.Annotations == nil {
+			lastPod.Annotations = make(map[string]string)
+		}
+		lastPod.Annotations[pendingTimeoutAnnotation] = "true"
+
+		var deadline int64 = 1
+		lastPod.Spec.ActiveDeadlineSeconds = &deadline
+
+		if err := r.Client.Update(ctx, lastPod); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{Requeue: true}, nil
 
 	case Wait:
 		Log.Info(InfoWaitingOnPod)


### PR DESCRIPTION
Recently a way to distinguish pending pods from running pods was added. This brings new opportunities for improvement in test-operator, including early exist for stuck (pending) pods.

This PR introduces parameter PendingTimeout, which will allow users to set the maximum time they are willing to wait for a pod in a pending state until it is marked as stuck. Once the limit is exceeded we can mark it as stuck and move onto the next pod.

This feature will also help in times, when the pods are stuck and therefore exceed the full testing time limit, resulting in no log collection. With this change the job should end early and have logs reporting the pending state.

One thing to note is that it is important to make sure pods that exceeded the pending timeout should be considered as failed by jobs. There should be no false positives by introducing this change!