### PR TITLE
Set TLS 1.3 as minimum version for webhook/metrics servers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,6 +99,10 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	tlsOpts = append(tlsOpts, func(c *tls.Config) {
+		c.MinVersion = tls.VersionTLS13
+	})
+
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
 	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and


### PR DESCRIPTION
Jira: [OSPRH-27313](https://redhat.atlassian.net/browse/OSPRH-27313)

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: John Fulton <fulton@redhat.com>
